### PR TITLE
COSBETA-265: 500 error on product page as poison centre user

### DIFF
--- a/cosmetics-web/app/views/poison_centres/notifications/_poison_centre_trigger_rule_formulation.html.slim
+++ b/cosmetics-web/app/views/poison_centres/notifications/_poison_centre_trigger_rule_formulation.html.slim
@@ -27,6 +27,6 @@ h2.govuk-heading-l.poison-centre__table-heading
                   - formulation_data = get_formulation_data(question, question_element)
                   - if formulation_data.present?
                     th.govuk-table__header[class="govuk-!-width-one-half" scope="row"]
-                      = formulation_data.first.humanize
+                      = formulation_data.first.answer.humanize
                     td.govuk-table__cell.govuk-table__cell--numeric
-                      = display_concentration(formulation_data.last.humanize)
+                      = display_concentration(formulation_data.last.answer.humanize)


### PR DESCRIPTION
As notify user, I can see below product in notified tab and I can see product details with no issues however same product as poison centre user it returns 500 error. Also I added this product just today through bulk upload and successfully added- However I think it spitted error in error tab.

## Description
Show humanized answer of a trigger rule element to a poison centre user

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
