### PR TITLE
PSD-1176 Only check correct teams are present if fetch succeeds

### DIFF
--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -29,12 +29,11 @@ class Team < ActiveHash::Base
     Organisation.load(force: force)
     begin
       self.data = Shared::Web::KeycloakClient.instance.all_teams(Organisation.all.map(&:id), force: force)
+      self.ensure_names_up_to_date
     rescue StandardError => e
       Rails.logger.error "Failed to fetch teams from Keycloak: #{e.message}"
       self.data = nil
     end
-
-    self.ensure_names_up_to_date
   end
 
   def self.all(options = {})


### PR DESCRIPTION
This fixes the problem of trying to operate on a `nil` `data` object at
times when the fetching was not successful.

Notably, the initialization happens not just when the server is booting,
but also for any rake task being run
(see https://guides.rubyonrails.org/v3.2/configuring.html#rails-general-configuration)
. In those cases the fetching has been observed to fail with
`Failed to open TCP connection to keycloak:8080 (Connection refused - connect(2) for \"keycloak\" port 8080)`
