### PR TITLE
PSD-1153 Alignment and content bugs

### DIFF
--- a/psd-web/app/views/teams/show.html.slim
+++ b/psd-web/app/views/teams/show.html.slim
@@ -4,7 +4,7 @@
     h1.govuk-heading-l = @team.display_name
     - if User.current.is_team_admin?
       a.govuk-button role="button" href=invite_to_team_url Invite a team member
-    h2.govuk-heading-m Team Members
+    h2.govuk-heading-m Team members
     ul.govuk-list
       - @team.users.sort_by(&:name).each do |user|
         li.teams--user class="govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0"

--- a/psd-web/app/views/teams/show.html.slim
+++ b/psd-web/app/views/teams/show.html.slim
@@ -9,7 +9,8 @@
       - @team.users.sort_by(&:name).each do |user|
         li.teams--user class="govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0"
           h3.teams--user-contact
-            span.govuk-heading-s.teams--user-name = user.name
+            - if user.name.present?
+              span.govuk-heading-s.teams--user-name = user.name
             '
             span.govuk-caption-m.teams--user-email = user.email
           - if user.is_team_admin?


### PR DESCRIPTION
Also [PSD-1154](https://regulatorydelivery.atlassian.net/browse/PSD-1154) as minor content change.

Only showing a span if username is present, to prevent misalignment on team members page
Changing 'Team Members' to 'Team members'.
