### PR TITLE
Cosbeta none fix logstash filters

### DIFF
--- a/infrastructure/logstash-filters.conf
+++ b/infrastructure/logstash-filters.conf
@@ -76,7 +76,7 @@ filter {
         }
     } else if [syslog_msg] =~ "^completeNotifications" {
         dissect {
-            mapping => { "syslog_msg" => "completeNotifications: %{complete_notifications}" }
+            mapping => { "syslog_msg" => "completeNotifications: %{complete_notifications}," }
             convert_datatype => {
                 "complete_notifications" => "int"
             }
@@ -84,7 +84,7 @@ filter {
         }
     } else if [syslog_msg] =~ "^responsiblePersons" {
         dissect {
-            mapping => { "syslog_msg" => "responsiblePersons: %{responsible_persons}" }
+            mapping => { "syslog_msg" => "responsiblePersons: %{responsible_persons}," }
             convert_datatype => {
                 "responsible_persons" => "int"
             }

--- a/infrastructure/logstash-filters.conf
+++ b/infrastructure/logstash-filters.conf
@@ -74,6 +74,14 @@ filter {
         } else {
             mutate { add_tag => ["_unknownmetricparsefailure"] }
         }
+    } else if [syslog_msg] =~ "^completeNotifications" {
+        dissect {
+            mapping => { "syslog_msg" => "completeNotifications: %{complete_notifications}" }
+            convert_datatype => {
+                "complete_notifications" => "int"
+            }
+            tag_on_failure => ["_completenotificationsparsefailure"]
+        }
     } else if [syslog_proc] =~ "APP" {
         # Other application logs
         mutate { add_tag => ["app"] }

--- a/infrastructure/logstash-filters.conf
+++ b/infrastructure/logstash-filters.conf
@@ -82,6 +82,14 @@ filter {
             }
             tag_on_failure => ["_completenotificationsparsefailure"]
         }
+    } else if [syslog_msg] =~ "^responsiblePersons" {
+        dissect {
+            mapping => { "syslog_msg" => "responsiblePersons: %{responsible_persons}" }
+            convert_datatype => {
+                "responsible_persons" => "int"
+            }
+            tag_on_failure => ["_responsiblepersonsparsefailure"]
+        }
     } else if [syslog_proc] =~ "APP" {
         # Other application logs
         mutate { add_tag => ["app"] }


### PR DESCRIPTION
This is a small fix to the logstash filters. It updates the syntax within the dissect function. 

With the comma present the data type conversion wasn't running. This in turn means that the fields were labelled as strings rather than numbers, which meant that the fields couldn't be used for visualizations on dashboards.