### PR TITLE
COSBETA243: Display component name for multi-component products

### DIFF
--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -91,6 +91,7 @@ private
   def set_component
     @component = Component.find(params[:component_id])
     authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
+    @component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
   end
 
   def component_params

--- a/cosmetics-web/app/controllers/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/trigger_questions_controller.rb
@@ -155,6 +155,7 @@ private
   def set_component
     @component = Component.find(params[:component_id])
     authorize @component.notification, policy_class: ResponsiblePersonNotificationPolicy
+    @component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
   end
 
   def set_question

--- a/cosmetics-web/app/views/component_build/add_cmrs.html.slim
+++ b/cosmetics-web/app/views/component_build/add_cmrs.html.slim
@@ -6,8 +6,9 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-xl
-      | Does the cosmetic product contain substances that are known or presumed to be
-      |  carcinogenic, mutagenic or toxic for reproduction?
+      | Does
+      =<> @component_name
+      | contain substances that are known or presumed to be carcinogenic, mutagenic or toxic for reproduction?
     p
       | These substance are commonly referred to as CMR.
     p

--- a/cosmetics-web/app/views/component_build/add_nanomaterial.html.slim
+++ b/cosmetics-web/app/views/component_build/add_nanomaterial.html.slim
@@ -6,7 +6,9 @@
 
     = form_with url: wizard_path, method: :put do |form|
       h1.govuk-heading-xl
-        | Which nanomaterials does the cosmetic product contain?
+        | Which nanomaterials does
+        =<> @component_name
+        | contain?
         - if @no_nano_element_selected
           span.govuk-error-message Please select at least an option before continuing
       .govuk-form-group

--- a/cosmetics-web/app/views/component_build/add_physical_form.html.slim
+++ b/cosmetics-web/app/views/component_build/add_physical_form.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title, "Single or multi component"
+- content_for :page_title, "Add physical form"
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
@@ -7,7 +7,7 @@
     .govuk-grid-column-two-thirds
       = render "form_components/govuk_error_summary", form: form
       = render "form_components/govuk_radios", form: form, key: :physical_form,
-              fieldset: { legend: { text: "What is the physical form of the cosmetic product?",
+              fieldset: { legend: { text: "What is the physical form of #{@component_name}?",
                       classes: "govuk-fieldset__legend--xl", isPageHeading: true } },
               items: Component.physical_forms.each.map { |key, value| \
                         { text: get_physical_form_name(key), value: value, checked: @component.physical_form == key } \

--- a/cosmetics-web/app/views/component_build/add_shades.html.slim
+++ b/cosmetics-web/app/views/component_build/add_shades.html.slim
@@ -4,7 +4,8 @@
 .govuk-grid-row
     .govuk-grid-column-two-thirds
         h1.govuk-heading-xl
-            | List the shades of the cosmetic product
+            | List the shades of
+            =< @component_name
         p
             | For each shade, all other aspects of the notification must be the same.
         - if @component.errors.messages[:shades].any?

--- a/cosmetics-web/app/views/component_build/contains_nanomaterials.html.slim
+++ b/cosmetics-web/app/views/component_build/contains_nanomaterials.html.slim
@@ -4,7 +4,9 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-xl
-      | Does the cosmetic product contain nanomaterials?
+      | Does
+      =<> @component_name
+      | contain nanomaterials?
     p
       | A ‘nanomaterial’:
 
@@ -19,7 +21,7 @@
         .govuk-radios
           .govuk-radios__item
             = form.radio_button :contains_nanomaterials, "yes", class: "govuk-radios__input"
-            = form.label :contains_nanomaterials_yes, "Yes, the cosmetic product contains nanomaterials",
+            = form.label :contains_nanomaterials_yes, "Yes, #{@component_name} contains nanomaterials",
                     class: "govuk-label govuk-radios__label"
           .govuk-radios__item
             = form.radio_button :contains_nanomaterials, "no", class: "govuk-radios__input"

--- a/cosmetics-web/app/views/component_build/number_of_shades.html.slim
+++ b/cosmetics-web/app/views/component_build/number_of_shades.html.slim
@@ -1,10 +1,12 @@
-- content_for :page_title, "Single or multi component"
+- content_for :page_title, "Number of shades"
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     h1.govuk-heading-xl
-      | Is the cosmetic product available in more than 1 shade?
+      | Is
+      =<> @component_name
+      | available in more than 1 shade?
     p
       | You can submit a single notification for all the shades this product is available in,
         if all other aspects of the notification are the same.
@@ -16,18 +18,18 @@
           .govuk-radios__item
             = form.radio_button :number_of_shades, "multiple-shades-same-notification", class: "govuk-radios__input"
             = form.label :number_of_shades,
-                    "Yes, the cosmetic product is available in more than 1 shade and all other aspects " \
+                    "Yes, #{@component_name} is available in more than 1 shade and all other aspects " \
                     + "of the notification are the same", value: "multiple-shades-same-notification",
                     class: "govuk-label govuk-radios__label"
           .govuk-radios__item
             = form.radio_button :number_of_shades, "multiple-shades-different-notification",
                     class: "govuk-radios__input"
             = form.label :number_of_shades,
-                    "Yes, the cosmetic product is available in more than 1 shade but needs separate notifications",
+                    "Yes, #{@component_name} is available in more than 1 shade but needs separate notifications",
                     value: "multiple-shades-different-notification", class: "govuk-label govuk-radios__label"
           .govuk-radios__item
             = form.radio_button :number_of_shades, "single-or-no-shades", class: "govuk-radios__input"
             = form.label :number_of_shades,
-                    "No, the cosmetic product is not available in more than 1 shade",
+                    "No, #{@component_name} is not available in more than 1 shade",
                     value: "single-or-no-shades", class: "govuk-label govuk-radios__label"
       = form.submit "Continue", class: "govuk-button"

--- a/cosmetics-web/app/views/component_build/select_category.html.slim
+++ b/cosmetics-web/app/views/component_build/select_category.html.slim
@@ -1,7 +1,7 @@
 ruby:
   question =
     if @category.present?
-      "What category of #{get_category_name(@category).downcase} is the product?"
+      "What category of #{get_category_name(@category).downcase} is #{@component_name}?"
     else
       "What category of cosmetic product is it?"
     end
@@ -16,8 +16,8 @@ ruby:
       = render "form_components/govuk_error_summary", form: form
       = render "form_components/govuk_radios", form: form, key: :sub_category,
               fieldset: { legend: { text: question, classes: "govuk-label--xl", isPageHeading: true } },
-              items: @sub_categories.map { |key| \
-                { text: get_category_name(key), value: key, checked: key == @selected_sub_category } \
+              items: @sub_categories.map { |category| \
+                { text: get_category_name(category), value: category, checked: category == @selected_sub_category } \
               }
       .govuk-form-group
         = form.submit "Continue", class: "govuk-button"

--- a/cosmetics-web/app/views/component_build/select_formulation_type.html.slim
+++ b/cosmetics-web/app/views/component_build/select_formulation_type.html.slim
@@ -5,11 +5,10 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
     = form_for(@component, url: wizard_path, method: :put) do |form|
-      - heading = capture do
-        h1.govuk-heading-xl How do you want to give the formulation of the cosmetic product?
       = render "form_components/govuk_radios", form: form, key: :notification_type,
               errorMessage: @no_notification_type_selected && { text: "Please select an option before continuing" },
-              fieldset: { legend: { html: heading } },
+              fieldset: { legend: { text: "How do you want to give the formulation of #{@component_name}?",
+                      classes: "govuk-fieldset__legend--xl", isPageHeading: true } },
               items: formulations_types_label.each.map { |type_key, type_text| \
                 { text: type_text, value: type_key.to_sym } \
               }

--- a/cosmetics-web/app/views/component_build/select_frame_formulation.html.slim
+++ b/cosmetics-web/app/views/component_build/select_frame_formulation.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title, "Add formulation"
+- content_for :page_title, "Choose frame formulation"
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 

--- a/cosmetics-web/app/views/component_build/upload_formulation.html.slim
+++ b/cosmetics-web/app/views/component_build/upload_formulation.html.slim
@@ -1,4 +1,4 @@
-- content_for :page_title, "Add formulation"
+- content_for :page_title, "Upload formulation document"
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
@@ -6,11 +6,8 @@
   .govuk-grid-column-two-thirds
     = render 'error_summary', errors: @component.errors
     h1.govuk-heading-xl
-      - if @component.notification.is_multicomponent?
-        ' Upload formulation document for component
-        = @component.name
-      - else
-        | Upload the formulation document
+      | Upload formulation document for
+      =< @component_name
     - if @component.exact?
       p This should be the exact concentration.
     - if @component.range?

--- a/cosmetics-web/app/views/notification_build/single_or_multi_component.html.slim
+++ b/cosmetics-web/app/views/notification_build/single_or_multi_component.html.slim
@@ -7,7 +7,7 @@
             | Is the cosmetic product available as single item or as a kit?
         p
             | Kits are composed of components that are not marketed separately.
-            | They are sold as a kit and intended to be used as a mix or sequentially.
+            |  They are sold as a kit and intended to be used as a mix or sequentially.
         p
             | Examples of multi-component cosmetics include:
         ul.govuk-list.govuk-list--bullet

--- a/cosmetics-web/app/views/notification_build/single_or_multi_component.html.slim
+++ b/cosmetics-web/app/views/notification_build/single_or_multi_component.html.slim
@@ -7,7 +7,7 @@
             | Is the cosmetic product available as single item or as a kit?
         p
             | Kits are composed of components that are not marketed separately.
-            |  They are sold as a kit and intended to be used as a mix or sequentially.
+              They are sold as a kit and intended to be used as a mix or sequentially.
         p
             | Examples of multi-component cosmetics include:
         ul.govuk-list.govuk-list--bullet

--- a/cosmetics-web/app/views/trigger_questions/_substance_check.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/_substance_check.html.slim
@@ -1,6 +1,5 @@
 ruby:
-  component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
-  question = local_assigns[:question] || "Does #{component_name} contain #{substance.pluralize}?"
+  question = local_assigns[:question] || "Does #{@component_name} contain #{substance.pluralize}?"
   yes_option = local_assigns[:yes_option] || "Yes, it has #{substance.pluralize}"
 
 = form_with model: @question, url: wizard_path, method: :put do |form|

--- a/cosmetics-web/app/views/trigger_questions/_substance_check_with_condition.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/_substance_check_with_condition.html.slim
@@ -1,6 +1,5 @@
 ruby:
-  component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
-  question = local_assigns[:question] || "Does #{component_name} contain #{substance.pluralize}?"
+  question = local_assigns[:question] || "Does #{@component_name} contain #{substance.pluralize}?"
   yes_option = local_assigns[:yes_option] || "Yes, the product contains #{substance}"
   label_text = local_assigns[:label_text] || "Total amount of #{substance} in the product"
 

--- a/cosmetics-web/app/views/trigger_questions/contains_cationic_surfactants.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/contains_cationic_surfactants.html.slim
@@ -3,7 +3,7 @@
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
 = render "trigger_questions/substance_check", substance: "cationic surfactant",
-        question: "Does the cosmetic product contain cationic surfactants with three or four chains" + \
+        question: "Does #{@component_name} contain cationic surfactants with three or four chains" + \
           " or groups with a length shorter than C12 (including straight, branched, cyclic or aromatic groups)?",
         yes_option: "Yes, it contains cationic surfactants with three or four chains" + \
           " or groups with a length shorter than C12"

--- a/cosmetics-web/app/views/trigger_questions/contains_vitamin_a.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/contains_vitamin_a.html.slim
@@ -3,7 +3,7 @@
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
 = render "trigger_questions/substance_check", substance: "vitamin A or its derivative",
-        question: "Does the cosmetic product contain more than 0.20% (calculated as retinol) or 0.09 grams" + \
+        question: "Does #{@component_name} contain more than 0.20% (calculated as retinol) or 0.09 grams" + \
           " (calculated as retinol) of vitamin A or its derivatives?",
         yes_option: "Yes, it contains more than 0.20% (calculated as retinol) or 0.09 grams (calculated as retinol)" + \
           " of vitamin A or its derivatives"

--- a/cosmetics-web/app/views/trigger_questions/contains_xanthine_derivatives.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/contains_xanthine_derivatives.html.slim
@@ -3,7 +3,7 @@
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
 = render "trigger_questions/substance_check", substance: "xanthine derivative",
-        question: "Does the cosmetic product contain more than 0.5% xanthine derivatives?",
+        question: "Does #{@component_name} contain more than 0.5% xanthine derivatives?",
         hint: "Xanthine derivatives include caffeine, theophylline, theobromine, plant extracts containing xanthine" + \
           " derivatives, for example, paulinia cupana (guarana) extracts or powders",
         yes_option: "Yes, it contains more than 0.5% xanthine derivatives?"

--- a/cosmetics-web/app/views/trigger_questions/exact_ph.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/exact_ph.html.slim
@@ -2,6 +2,5 @@
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
-- component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
-= render "trigger_questions/substance_text_input", question: "What is the pH of #{component_name}?",
+= render "trigger_questions/substance_text_input", question: "What is the pH of #{@component_name}?",
         classes: "govuk-input--width-10"

--- a/cosmetics-web/app/views/trigger_questions/ph_mixed_hair_dye.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/ph_mixed_hair_dye.html.slim
@@ -3,6 +3,6 @@
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
 = render "trigger_questions/substance_check_with_condition", substance: "pH of mixed hair dye", prefix_text: "pH",
-        question: "Is the cosmetic product a hair dye that needs to be mixed?",
+        question: "Is #{@component_name} a hair dye that needs to be mixed?",
         yes_option: "Yes, the product is a hair dye that needs to be mixed",
         label_text: "pH of the hair dye after mixing?"

--- a/cosmetics-web/app/views/trigger_questions/ph_mixed_product.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/ph_mixed_product.html.slim
@@ -3,6 +3,6 @@
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
 = render "trigger_questions/substance_check_with_condition", substance: "components mixed pH", prefix_text: "pH",
-        question: "Do the components of the cosmetic product need to be mixed?",
+        question: "Do the components of #{@component_name} need to be mixed?",
         yes_option: "Yes, the components need to be mixed",
         label_text: "pH of the product after mixing?"

--- a/cosmetics-web/app/views/trigger_questions/select_ph_range.html.slim
+++ b/cosmetics-web/app/views/trigger_questions/select_ph_range.html.slim
@@ -2,13 +2,12 @@
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
-- component_name = @component.notification.is_multicomponent? ? @component.name : "the cosmetic product"
 = form_with model: @question, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       = render "form_components/govuk_error_summary", form: form
       = render "form_components/govuk_radios", form: form, key: :range,
-              fieldset: { legend: { text: "What is the pH of #{component_name}?", \
+              fieldset: { legend: { text: "What is the pH of #{@component_name}?", \
                                     classes: "govuk-fieldset__legend--xl", isPageHeading: true } },
               items: [{ text: "Below 3", value: "below" },
                       { text: "Between 3 and 10", value: "between" },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

COSBETA243: Display component name when it's a multi-component

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
