### PR TITLE
COSBETA-410: Stop creating empty trigger question rules

### DIFF
--- a/cosmetics-web/app/controllers/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/trigger_questions_controller.rb
@@ -26,7 +26,7 @@ class TriggerQuestionsController < ApplicationController
         :contains_isopropanol
 
   before_action :set_component
-  before_action :set_question
+  before_action :set_question, only: %i[show update]
 
   def show
     initialize_step
@@ -159,7 +159,7 @@ private
 
   def set_question
     question = get_question_for_step step
-    @question = TriggerQuestion.find_or_create_by(component: @component, question: question)
+    @question = TriggerQuestion.find_or_create_by(component: @component, question: question) if question.present?
   end
 
   def initialize_step


### PR DESCRIPTION
COSBETA-410: Stop creating empty trigger question rules
when starting the trigger questions rules on the manual journey

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
