### PR TITLE
COSBETA-408: Under three years old question

### DIFF
--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -143,13 +143,7 @@ private
 
   def render_number_of_shades
     case params[:number_of_shades]
-    when "single-or-no-shades"
-      @component.shades = nil
-      @component.add_shades
-      @component.save
-      jump_to(next_step(:add_shades))
-      render_wizard @component
-    when "multiple-shades-different-notification"
+    when "single-or-no-shades", "multiple-shades-different-notification"
       @component.shades = nil
       @component.add_shades
       @component.save

--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -147,12 +147,14 @@ private
       @component.shades = nil
       @component.add_shades
       @component.save
-      redirect_to wizard_path(:add_physical_form, component_id: @component.id)
+      jump_to(next_step(:add_shades))
+      render_wizard @component
     when "multiple-shades-different-notification"
       @component.shades = nil
       @component.add_shades
       @component.save
-      redirect_to wizard_path(:add_physical_form, component_id: @component.id)
+      jump_to(next_step(:add_shades))
+      render_wizard @component
     when "multiple-shades-same-notification"
       render_wizard @component
     when ""
@@ -193,7 +195,8 @@ private
       render_wizard @component
     when "no"
       destroy_all_cmrs
-      redirect_to wizard_path(:contains_nanomaterials, component_id: @component.id)
+      jump_to(next_step(:add_cmrs))
+      render_wizard @component
     else
       @component.errors.add :contains_cmrs, "Please select an option"
       render step
@@ -216,7 +219,8 @@ private
       render_wizard @component
     when "no"
       @nano_material.destroy if @nano_material.present?
-      redirect_to wizard_path(:select_category, component_id: @component.id)
+      jump_to(next_step(:list_nanomaterials))
+      render_wizard @component
     else
       @component.errors.add :contains_nanomaterials, "Please select an option"
       render step
@@ -264,7 +268,7 @@ private
         render_wizard @component
       end
     else
-      @component.errors.add :sub_category, "Please select an option"
+      @component.errors.add :sub_category, "Choose an option"
       render step
     end
   end
@@ -277,11 +281,11 @@ private
     @component.update(component_params)
     if @component.predefined?
       @component.formulation_file.delete if @component.formulation_file.attached?
-      render_wizard @component
     else
       @component.update(frame_formulation: nil) unless @component.frame_formulation.nil?
-      redirect_to wizard_path(:upload_formulation, component_id: @component.id)
+      jump_to(next_step(:select_frame_formulation))
     end
+    render_wizard @component
   end
 
   def render_select_frame_formulation

--- a/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/manual_notification_concern.rb
@@ -3,7 +3,9 @@ module ManualNotificationConcern
   include Wicked::Wizard
 
   def notification
-    if params[:notification_id]
+    if params[:notification_reference_number]
+      Notification.find_by reference_number: params[:notification_reference_number]
+    elsif params[:notification_id]
       Notification.find(params[:notification_id])
     elsif params[:component_id]
       component = Component.find(params[:component_id])

--- a/cosmetics-web/app/controllers/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/notification_build_controller.rb
@@ -105,12 +105,9 @@ private
   end
 
   def render_for_children_under_three_step
-    case notification_params[:under_three_years]
-    when "true", "false"
-      @notification.update(notification_params)
+    if @notification.update_with_context(notification_params, :for_children_under_three)
       render_wizard @notification
     else
-      @notification.errors.add :under_three_years, "Please select an option"
       render step
     end
   end

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -33,6 +33,7 @@ class Notification < ApplicationRecord
   validates :cpnp_reference, uniqueness: { scope: :responsible_person, message: duplicate_notification_message },
             allow_nil: true
   validates :cpnp_reference, presence: true, on: :file_upload
+  validates :under_three_years, inclusion: { in: [true, false] }, on: :for_children_under_three
   validates :components_are_mixed, inclusion: { in: [true, false] }, on: :update_components_are_mixed
   validates :ph_min_value, :ph_max_value, presence: true, on: :update_ph_range_value
   validates :ph_min_value, :ph_max_value, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 14 },

--- a/cosmetics-web/app/views/notification_build/for_children_under_three.html.slim
+++ b/cosmetics-web/app/views/notification_build/for_children_under_three.html.slim
@@ -1,16 +1,15 @@
-- content_for :page_title, "Is the product specifically intended for children under 3 years of age"
+- content_for :page_title, "For children under 3"
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
-- title_text = "Is the product specifically intended for children under 3 years of age?"
+- title_text = "Is the product intended for children under 3?"
 
 = form_with model: @notification, url: wizard_path, method: :put do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds
       = render "form_components/govuk_error_summary", form: form
-      = render "components/govuk_fieldset",
-              legend: { text: title_text, classes: "govuk-label--xl", isPageHeading: true } do
-        = render "form_components/govuk_radios", form: form, key: :under_three_years,
-                items: [{ text: "Yes", value: "true" },
-                        { text: "No", value: "false" }]
-        = form.submit "Continue", class: "govuk-button"
+      = render "form_components/govuk_radios", form: form, key: :under_three_years,
+              fieldset: { legend: { text: title_text, classes: "govuk-fieldset__legend--xl", isPageHeading: true } },
+              items: [{ text: "Yes", value: "true" },
+                      { text: "No", value: "false" }]
+      = form.submit "Continue", class: "govuk-button"

--- a/cosmetics-web/app/views/notification_build/for_children_under_three.html.slim
+++ b/cosmetics-web/app/views/notification_build/for_children_under_three.html.slim
@@ -1,0 +1,16 @@
+- content_for :page_title, "Is the product specifically intended for children under 3 years of age"
+- content_for :after_header do
+  = link_to "Back", previous_wizard_path, class: "govuk-back-link"
+
+- title_text = "Is the product specifically intended for children under 3 years of age?"
+
+= form_with model: @notification, url: wizard_path, method: :put do |form|
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = render "form_components/govuk_error_summary", form: form
+      = render "components/govuk_fieldset",
+              legend: { text: title_text, classes: "govuk-label--xl", isPageHeading: true } do
+        = render "form_components/govuk_radios", form: form, key: :under_three_years,
+                items: [{ text: "Yes", value: "true" },
+                        { text: "No", value: "false" }]
+        = form.submit "Continue", class: "govuk-button"

--- a/cosmetics-web/app/views/notifications/_product_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_product_details.html.slim
@@ -27,7 +27,7 @@ table.govuk-table.check-your-answers-table#product-table
     - if notification.notified_post_eu_exit?
       tr.govuk-table__row
         th.govuk-table__header
-          | Is the product specifically intended for children under 3 years of age?
+          | For children under 3
         td.govuk-table__cell
           = notification.under_three_years ? "Yes" : "No"
     tr.govuk-table__row

--- a/cosmetics-web/app/views/notifications/_product_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_product_details.html.slim
@@ -24,6 +24,12 @@ table.govuk-table.check-your-answers-table#product-table
           | Imported from
         td.govuk-table__cell
           = product_import_country(notification)
+    - if notification.notified_post_eu_exit?
+      tr.govuk-table__row
+        th.govuk-table__header
+          | Is the product specifically intended for children under 3 years of age?
+        td.govuk-table__cell
+          = notification.under_three_years ? "Yes" : "No"
     tr.govuk-table__row
       th.govuk-table__header[scope="row"]
         | Number of components

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
           attributes:
             components_are_mixed:
               inclusion: "Select an option"
+            under_three_years:
+              inclusion: "Choose an option"
         trigger_question:
           attributes:
             applicable:

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe NotificationBuildController, type: :controller do
       expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, notification, :add_import_country))
     end
 
-    it "skips add_import_country step if is_imported set to false" do
-      post(:update, params: params.merge(id: :is_imported, is_imported: false))
-      expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, notification, :single_or_multi_component))
+    it "redirects to for_children_under_three step if is_imported set to false and post-eu-exit (default)" do
+      post(:update, params: params.merge(id: :is_imported, is_imported: false, was_notified_before_eu_exit: "false"))
+      expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, notification, :for_children_under_three))
     end
 
     it "adds an error if user doesn't pick a radio option for is_imported" do
@@ -112,8 +112,13 @@ RSpec.describe NotificationBuildController, type: :controller do
       expect(assigns(:notification).errors[:import_country]).to include("Must not be blank")
     end
 
-    it "continues to next step if user submits import_country with a valid value" do
+    it "continues to next step if user submits import_country with a valid value and post-eu-exit (default)" do
       post(:update, params: params.merge(id: :add_import_country, notification: { import_country: "France" }))
+      expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, notification, :for_children_under_three))
+    end
+
+    it "continues to next step if user submits under_three_years with a valid value" do
+      post(:update, params: params.merge(id: :for_children_under_three, notification: { under_three_years: "true" }))
       expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, notification, :single_or_multi_component))
     end
 

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
     factory :registered_notification do
       state { :notification_complete }
     end
+
+    factory :pre_eu_exit_notification do
+      was_notified_before_eu_exit { true }
+    end
   end
 end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -27,4 +27,15 @@ RSpec.describe Notification, type: :model do
       expect(notification.errors[:product_name]).to include('must not be blank')
     end
   end
+
+  describe "updating under three years" do
+    it "adds errors if under_three_years updated to be blank" do
+      notification = create(:notification)
+
+      notification.under_three_years = nil
+      notification.save(context: :for_children_under_three)
+
+      expect(notification.errors[:under_three_years]).to include('Choose an option')
+    end
+  end
 end

--- a/cosmetics-web/spec/system/manual_notification_entry_spec.rb
+++ b/cosmetics-web/spec/system/manual_notification_entry_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Manually enter product details", type: :system do
     notification = get_notification_from_edit_page_url
     expect_check_your_answer(get_product_table, "Name", "Super Shampoo")
     expect_check_your_answers_value("Imported", "No")
-    expect_check_your_answers_value("Is the product specifically intended for children under 3 years of age?", "No")
+    expect_check_your_answers_value("Is the product intended for children under 3?", "No")
     expect_check_your_answers_value("Number of components", "1")
     expect_check_your_answers_value("Shades", "None")
     expect_check_your_answers_value("Label image", "testImage.png")

--- a/cosmetics-web/spec/system/manual_notification_entry_spec.rb
+++ b/cosmetics-web/spec/system/manual_notification_entry_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe "Manually enter product details", type: :system do
     choose("No")
     click_button "Continue"
 
+    # for_children_under_three
+    choose("No")
+    click_button "Continue"
+
     # single_or_multi_component
     choose("The cosmetic product is a single item")
     click_button "Continue"
@@ -70,6 +74,7 @@ RSpec.describe "Manually enter product details", type: :system do
     notification = get_notification_from_edit_page_url
     expect_check_your_answer(get_product_table, "Name", "Super Shampoo")
     expect_check_your_answers_value("Imported", "No")
+    expect_check_your_answers_value("Is the product specifically intended for children under 3 years of age?", "No")
     expect_check_your_answers_value("Number of components", "1")
     expect_check_your_answers_value("Shades", "None")
     expect_check_your_answers_value("Label image", "testImage.png")
@@ -91,6 +96,10 @@ RSpec.describe "Manually enter product details", type: :system do
     click_button "Continue"
 
     # is_imported
+    choose("No")
+    click_button "Continue"
+
+    # for_children_under_three
     choose("No")
     click_button "Continue"
 
@@ -153,6 +162,10 @@ RSpec.describe "Manually enter product details", type: :system do
 
     # add_import_country
     fill_autocomplete "location-autocomplete", with: "New Zealand"
+    click_button "Continue"
+
+    # for_children_under_three
+    choose("No")
     click_button "Continue"
 
     # single_or_multi_component
@@ -219,6 +232,10 @@ RSpec.describe "Manually enter product details", type: :system do
     click_button "Continue"
 
     # is_imported
+    choose("No")
+    click_button "Continue"
+
+    # for_children_under_three
     choose("No")
     click_button "Continue"
 

--- a/cosmetics-web/spec/system/manual_notification_entry_spec.rb
+++ b/cosmetics-web/spec/system/manual_notification_entry_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Manually enter product details", type: :system do
     notification = get_notification_from_edit_page_url
     expect_check_your_answer(get_product_table, "Name", "Super Shampoo")
     expect_check_your_answers_value("Imported", "No")
-    expect_check_your_answers_value("Is the product intended for children under 3?", "No")
+    expect_check_your_answers_value("For children under 3", "No")
     expect_check_your_answers_value("Number of components", "1")
     expect_check_your_answers_value("Shades", "None")
     expect_check_your_answers_value("Label image", "testImage.png")


### PR DESCRIPTION
As part of the manual journey, add a page to capture whether the product is intended for children under 3 years of age.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
