### PR TITLE
PSD-1181: Disabled fuzzy transpositions for exact fields and changed …

### DIFF
--- a/psd-web/app/helpers/elasticsearch_query.rb
+++ b/psd-web/app/helpers/elasticsearch_query.rb
@@ -84,7 +84,8 @@ private
       multi_match: {
         query: query,
         fields: @exact_fields,
-        type: "phrase"
+        type: "phrase",
+        fuzzy_transpositions: "false"
       }
     }
   end

--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -27,15 +27,15 @@ module Investigations::DisplayTextHelper
   end
 
   def pretty_source(source)
-    replace_unsightly_field_names(source).gsub('.', ', ').humanize
+    replace_unsightly_field_names(source).gsub('.', ', ')
   end
 
   def replace_unsightly_field_names(field_name)
     pretty_field_names = {
-      pretty_id: "Case id",
+      pretty_id: "Case ID",
       "activities.search_index": "Activities, comment"
     }
-    pretty_field_names[field_name.to_sym] || field_name
+    pretty_field_names[field_name.to_sym] || field_name.humanize
   end
 
   def get_highlight_content(result)

--- a/psd-web/app/views/investigations/_highlight_card.html.slim
+++ b/psd-web/app/views/investigations/_highlight_card.html.slim
@@ -7,7 +7,5 @@
     span = link_to investigation.title, investigation, class: "govuk-!-font-weight-bold"
   .govuk-grid-column-one-half
     - displayable_highlights.each do |highlight|
-      - label = capture do
-        = highlight[:label] == "Case id" ? "Case ID" : highlight[:label]
-      span.govuk-caption-m[class="govuk-!-font-size-16"] = label
+      span.govuk-caption-m[class="govuk-!-font-size-16"] = highlight[:label]
       span = highlight[:content]

--- a/psd-web/app/views/investigations/_highlight_card.html.slim
+++ b/psd-web/app/views/investigations/_highlight_card.html.slim
@@ -7,5 +7,7 @@
     span = link_to investigation.title, investigation, class: "govuk-!-font-weight-bold"
   .govuk-grid-column-one-half
     - displayable_highlights.each do |highlight|
-      span.govuk-caption-m[class="govuk-!-font-size-16"] = highlight[:label]
+      - label = capture do
+        = highlight[:label] == "Case id" ? "Case ID" : highlight[:label]
+      span.govuk-caption-m[class="govuk-!-font-size-16"] = label
       span = highlight[:content]


### PR DESCRIPTION
…'Case id' to 'Case ID'

## Description
Turned out it was a simple change that was hard to find. For some reason by default the term query has something called fuzzy transpositions (ab → ba) enabled by default. Disabling this for exact fields (which only contains case id) solves the problem, and now only brings exact matches to case ID's. For example searching:
1907-0009
brings only 1 case with that ID and no longer:
1907-0090
1907-000
1970-0009

Also changed id to be capitalised in the highlighted field.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
