### PR TITLE
Updating psd dockerfile to match cosmetics

### DIFF
--- a/psd-web/Dockerfile
+++ b/psd-web/Dockerfile
@@ -13,15 +13,10 @@ RUN curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add
 RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main"  | tee /etc/apt/sources.list.d/google.list
 
 RUN apt-get update && apt-get install -y \ 
-  build-essential \ 
+  build-essential \
   nodejs \
   yarn \
-  zlib1g-dev \
-  liblzma-dev \
-  xvfb \
   unzip \
-  libgconf2-4 \
-  libnss3 \
   google-chrome-stable
 
 RUN curl -o /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/$CHROMIUM_DRIVER_VERSION/chromedriver_linux64.zip \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->
libgconf can't be found by apt-install and isn't needed
Other apt-install like xvfb don't need to be there as they're automatically installed