### PR TITLE
Remove Nanomaterial navigational link

### DIFF
--- a/cosmetics-web/app/views/layouts/_navbar.html.slim
+++ b/cosmetics-web/app/views/layouts/_navbar.html.slim
@@ -4,11 +4,6 @@ nav.app-navigation.govuk-clearfix
       = link_to "Cosmetic products", responsible_person_notifications_path(@responsible_person),
               "data-topnav": "responsible_persons/notifications",
               class: "govuk-link--no-visited-state"
-    li[
-    class=(params[:controller] == "responsible_persons/non_standard_nanomaterials" && "app-navigation--current-page")]
-      = link_to "Nanomaterials", responsible_person_non_standard_nanomaterials_path(@responsible_person),
-              "data-topnav": "responsible_persons/non_standard_nanomaterials",
-              class: "govuk-link--no-visited-state"
     li[class=(params[:controller] == "responsible_persons" && "app-navigation--current-page")]
       = link_to "Responsible person details", responsible_person_path(@responsible_person),
               "data-topnav": "responsible_persons",


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-534

## Description
Remove the Nanomaterial navigational link in preparation for the public beta.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
