### PR TITLE
COSBETA-538 - Check if RP has notified non-standard nanomaterial

### DIFF
--- a/cosmetics-web/app/controllers/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_build_controller.rb
@@ -1,7 +1,12 @@
 class NanomaterialBuildController < ApplicationController
   include Wicked::Wizard
 
-  steps :select_purposes, :confirm_restrictions, :confirm_usage, :non_standard_nanomaterial_notified
+  steps :select_purposes,
+        :confirm_restrictions,
+        :confirm_usage,
+        :non_standard_nanomaterial_notified,
+        :committee_on_toxicology_notified,
+        :committee_on_toxicology_not_notified
 
   before_action :set_component
   before_action :set_nano_element
@@ -22,6 +27,8 @@ class NanomaterialBuildController < ApplicationController
       render_confirm_restrictions_step
     when :confirm_usage
       render_confirm_usage_step
+    when :non_standard_nanomaterial_notified
+      render_non_standard_nanomaterial_step
     end
   end
 
@@ -35,6 +42,8 @@ class NanomaterialBuildController < ApplicationController
       responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :list_nanomaterials)
     when :confirm_usage, :non_standard_nanomaterial_notified
       wizard_path(:select_purposes)
+    when :committee_on_toxicology_notified, :committee_on_toxicology_not_notified
+      wizard_path(:non_standard_nanomaterial_notified)
     else
       super
     end
@@ -101,6 +110,22 @@ private
       redirect_to wizard_path(:non_standard_nanomaterial_notified)
     else
       @nano_element.errors.add :confirm_usage, "Select an option"
+      render step
+    end
+  end
+
+  def render_non_standard_nanomaterial_step
+    confirm_toxicology_notified = params.dig(:nano_element, :confirm_toxicology_notified)
+
+    case confirm_toxicology_notified
+    when "yes"
+      redirect_to wizard_path(:committee_on_toxicology_notified)
+    when "no"
+      redirect_to wizard_path(:committee_on_toxicology_not_notified)
+    when "not sure"
+      redirect_to wizard_path(:committee_on_toxicology_not_notified)
+    else
+      @nano_element.errors.add :confirm_toxicology_notified, "Select an option"
       render step
     end
   end

--- a/cosmetics-web/app/views/nanomaterial_build/committee_on_toxicology_not_notified.html.slim
+++ b/cosmetics-web/app/views/nanomaterial_build/committee_on_toxicology_not_notified.html.slim
@@ -1,0 +1,10 @@
+- title = "Not confirmed"
+
+- content_for :page_title, title
+- content_for :after_header do
+  = link_to "Back", previous_wizard_path, class: "govuk-back-link"
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl
+      = title

--- a/cosmetics-web/app/views/nanomaterial_build/committee_on_toxicology_notified.html.slim
+++ b/cosmetics-web/app/views/nanomaterial_build/committee_on_toxicology_notified.html.slim
@@ -1,0 +1,10 @@
+- title = "Confirmed"
+
+- content_for :page_title, title
+- content_for :after_header do
+  = link_to "Back", previous_wizard_path, class: "govuk-back-link"
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl
+      = title

--- a/cosmetics-web/app/views/nanomaterial_build/non_standard_nanomaterial_notified.html.slim
+++ b/cosmetics-web/app/views/nanomaterial_build/non_standard_nanomaterial_notified.html.slim
@@ -1,9 +1,18 @@
-- title = "Select nanomaterial purpose"
+- title = "Have you submitted a notification about #{@nano_element.inci_name} in the UK since Brexit?"
+- question = title
+- items = [{ text: "Yes", value: "yes" }, { text: "No", value: "no" }, { text: "Not sure", value: "not sure" }]
 
 - content_for :page_title, title
 - content_for :after_header do
   = link_to "Back", previous_wizard_path, class: "govuk-back-link"
 
-h1 Non-standard Nanomaterials Notified
-p
-  | Go back and select a different option
+= form_with(model: @nano_element, url: wizard_path, method: :put) do |form|
+  .govuk-grid-row
+    .govuk-grid-column-two-thirds
+      = render "form_components/govuk_error_summary", form: form
+      = render "form_components/govuk_radios",
+        form: form,
+          key: :confirm_toxicology_notified,
+            fieldset: { legend: { text: question, classes: "govuk-label--xl", isPageHeading: true } },
+              items: items
+      = form.submit "Continue", class: "govuk-button"


### PR DESCRIPTION
## Description
Add content for non_standard_nanomaterial_notified and create dummy pages for the next steps in the journey

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
