### PR TITLE
COSBETA-493 [BUGFIX] Resolve validation issue with uploading frame formula.

### DIFF
--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -267,9 +267,15 @@ private
 
   def render_upload_formulation
     formulation_file = params.dig(:component, :formulation_file)
+
     if formulation_file.present?
       @component.formulation_file.attach(formulation_file)
-      redirect_to finish_wizard_path
+      if @component.valid?
+        redirect_to finish_wizard_path
+      else
+        @component.formulation_file.delete if @component.formulation_file.attached?
+        render step
+      end
     else
       @component.errors.add :formulation_file, "Please upload a file"
       render step


### PR DESCRIPTION
## Description
Make sure that we validation formula files when the user uploads them and display the validation error on the correct page.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
