### PR TITLE
Re-try bulk assignment of self.data on failure

### DIFF
--- a/psd-web/app/models/concerns/active_hash_safe_loadable.rb
+++ b/psd-web/app/models/concerns/active_hash_safe_loadable.rb
@@ -1,0 +1,15 @@
+module ActiveHashSafeLoadable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def safe_load(data_to_load, data_name:, retries: 3)
+      begin
+        self.data = data_to_load
+        Rails.logger.debug "ActiveHashSafeLoadable.safe_load: #{data_name} success with remaining tries: #{retries}"
+      rescue StandardError => e
+        Rails.logger.error "Failed to load #{data_name} (remaining retries #{retries}): #{e.message}"
+        self.safe_load(data_to_load, data_name: data_name, retries: retries - 1) if retries.positive?
+      end
+    end
+  end
+end

--- a/psd-web/app/models/organisation.rb
+++ b/psd-web/app/models/organisation.rb
@@ -1,4 +1,14 @@
 class Organisation < Shared::Web::Organisation
+  include ActiveHashSafeLoadable
   has_many :teams, dependent: :nullify
+
+  def self.load(force: false)
+    begin
+      self.safe_load(Shared::Web::KeycloakClient.instance.all_organisations(force: force), data_name: 'organisations')
+    rescue StandardError => e
+      Rails.logger.error "Failed to fetch organisations from Keycloak: #{e.message}"
+      self.data = nil
+    end
+  end
 end
 Organisation.load if Rails.env.development?

--- a/psd-web/app/models/team.rb
+++ b/psd-web/app/models/team.rb
@@ -1,5 +1,6 @@
 class Team < ActiveHash::Base
   include ActiveHash::Associations
+  include ActiveHashSafeLoadable
 
   field :id
   field :name
@@ -30,7 +31,8 @@ class Team < ActiveHash::Base
   def self.load(force: false)
     Organisation.load(force: force)
     begin
-      self.data = Shared::Web::KeycloakClient.instance.all_teams(Organisation.all.map(&:id), force: force)
+      teams = Shared::Web::KeycloakClient.instance.all_teams(Organisation.all.map(&:id), force: force)
+      self.safe_load(teams, data_name: 'teams')
       self.ensure_names_up_to_date
     rescue StandardError => e
       Rails.logger.error "Failed to fetch teams from Keycloak: #{e.message}"

--- a/psd-web/app/models/team_user.rb
+++ b/psd-web/app/models/team_user.rb
@@ -1,14 +1,17 @@
 class TeamUser < ActiveHash::Base
   include ActiveHash::Associations
+  include ActiveHashSafeLoadable
 
   belongs_to :team
   belongs_to :user
 
   def self.load(force: false)
     begin
-      self.data = Shared::Web::KeycloakClient.instance.all_team_users(
+      team_users = Shared::Web::KeycloakClient.instance.all_team_users(
         User.all.map(&:id), Team.all.map(&:id), force: force
       )
+
+      self.safe_load(team_users, data_name: 'team_users')
     rescue StandardError => e
       Rails.logger.error "Failed to fetch team memberships from Keycloak: #{e.message}"
       self.data = nil

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < Shared::Web::User
+  include ActiveHashSafeLoadable
+
   has_many :activities, dependent: :nullify
   has_many :investigations, dependent: :nullify, as: :assignable
   has_many :user_sources, dependent: :delete
@@ -47,10 +49,12 @@ class User < Shared::Web::User
       # - however, checking this based on permissions would require a request per user
       # Some user object are missing their name when they have not finished their registration yet.
       # But we need to be able to show them on the teams page for example, so we ensure that the attribute is not nil
-      self.data = all_users.deep_dup # We want a copy of the data to modify freely, not mutating the cached version
+      users = all_users.deep_dup # We want a copy of the data to modify freely, not mutating the cached version
                       .map(&method(:populate_organisation))
                       .map(&method(:populate_name))
                       .reject { |user| user[:organisation_id].blank? }
+
+      self.safe_load(users, data_name: 'users')
     rescue StandardError => e
       Rails.logger.error "Failed to fetch users from Keycloak: #{e.message}"
       self.data = nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Ticket: https://trello.com/c/tzbTEwby

In various models based on ActiveHash, data from Keycloak was assigned in bulk by means of `self.data =` - under heavy loads this has randomly lead to `Duplicate key` errors from ActiveHash.

Here we add a re-try mechanism if this occurs.

In local stress tests using JMeter, this approach prevented all status 500 errors that were happening before the changes. The logs revealed that only one retry was every necessary to successfully assign the Keycloak data.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
