### PR TITLE
Allow 'lograge' to be disabled from an env variable

### DIFF
--- a/shared-web/config/initializers/lograge.rb
+++ b/shared-web/config/initializers/lograge.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.configure do
-  config.lograge.enabled = true
+  config.lograge.enabled = ENV.fetch('LOGRAGE_ENABLED', 'true') == 'true'
 
   config.lograge.custom_payload do |_controller|
     extra_payload = {}


### PR DESCRIPTION
This alters the 'lograge' configuration to enable it to be turned off by setting a `LOGRAGE_ENABLED` environment variable to `false`. It remains enabled by default if no environment variable is present.

[Lograge](https://github.com/roidrage/lograge) is a Ruby gem which changes the default Rails logging format to make it less verbose, instead having a single line of information. Whilst this may be useful for production environments, I've found it to be frustrating in development, as the default Rails logging contains useful information such as the parameters, and each view and partial being rendered.

With lograge:

<img width="934" alt="Screenshot 2019-09-19 at 17 07 16" src="https://user-images.githubusercontent.com/30665/65261343-f7c66200-daff-11e9-9f49-a1ab2ca5db7e.png">

Without lograge (Rails default):

<img width="858" alt="Screenshot 2019-09-19 at 17 06 44" src="https://user-images.githubusercontent.com/30665/65261358-03198d80-db00-11e9-9fdb-aa7777bcbd8d.png">
