### PR TITLE
Allow Redis URL to be configured via environment variable

### DIFF
--- a/cosmetics-web/config/redis.yml
+++ b/cosmetics-web/config/redis.yml
@@ -1,5 +1,5 @@
 default: &default
-  host: 'redis'
+  url: <%= ENV.fetch('REDIS_URL', 'redis://redis:6379') %>
 
 development:
   <<: *default


### PR DESCRIPTION
The existing configuration assumes that Redis is running on a host called `redis` in development and test environments.  This change allows this default to be overriden by setting a  `REDIS_URL` environment variable.

This is useful, I think, as running Redis locally on the `redis` host means altering your `/etc/hosts` file, which is a minor inconvenience and not necessarily obvious.