### PR TITLE
Add banner to non-opss page

### DIFF
--- a/psd-web/app/views/homepage/non_opss.html.slim
+++ b/psd-web/app/views/homepage/non_opss.html.slim
@@ -1,5 +1,10 @@
 - content_for :page_title, "Home Page"
-
+- banner_content = capture do
+  p
+    strong = "We’re aware of intermittent problems with the service."
+  p = "Thank you for your patience while we investigate."
+  p = "(Last updated 24 September 2019)"
+= render "components/hmcts_banner", html: banner_content
 .govuk-grid-row
   .govuk-grid-column-two-thirds-from-desktop
     h1.govuk-heading-l


### PR DESCRIPTION
Adding a banner to raise our awareness of the bugs on the service. To be present until we've fixed them.
