### PR TITLE
Bugfix: radio boolean values should be specified as strings

### DIFF
--- a/cosmetics-web/app/views/component_build/contains_poisonous_ingredients.html.slim
+++ b/cosmetics-web/app/views/component_build/contains_poisonous_ingredients.html.slim
@@ -138,7 +138,7 @@
 
       = render "form_components/govuk_radios", form: form, key:   :contains_poisonous_ingredients,
               fieldset: { legend: { text: question, classes: "govuk-fieldset__legend--m", isPageHeading: false } },
-              items: [{ text: "Yes", value: true },
-                      { text: "No", value: false }]
+              items: [{ text: "Yes", value: "true" },
+                      { text: "No", value: "false" }]
 
       = form.submit "Continue", class: "govuk-button"


### PR DESCRIPTION
Values for the radio button fields should be strings, otherwise our template doesn't include them... 🤦‍♂ 