### PR TITLE
Ignore Redis snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ $RECYCLE.BIN/
 psd-web/.ruby-gemset
 
 *.log
+
+# Redis snapshots. See https://redis.io/topics/persistence
+dump.rdb


### PR DESCRIPTION
When running the [Redis](https://redis.io) server locally, by default it saves periodic [snapshots](https://redis.io/topics/persistence#snapshotting) to a file named `dump.rdb`.

This tells Git to ignore this file, so that it doesn’t accidentally get committed.