### PR TITLE
Skip poisonous ingredients question for pre-Brexit products

### DIFF
--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -275,7 +275,7 @@ private
   end
 
   def update_frame_formulation
-    if @component.update_with_context(component_params, :update_frame_formulation)
+    if @component.update_with_context(component_params, :select_frame_formulation)
 
       if @component.notification.notified_post_eu_exit?
         # Redirect to "Contains poisonous ingredients?" question
@@ -284,7 +284,7 @@ private
         redirect_to responsible_person_notification_component_trigger_question_path(@component.notification.responsible_person, @component.notification, @component, :select_ph_range)
       end
     else
-      render :update_frame_formulation
+      render :select_frame_formulation
     end
   end
 

--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -59,6 +59,8 @@ class ComponentBuildController < ApplicationController
       render_select_category_step
     when :select_formulation_type
       render_select_formulation_type
+    when :select_frame_formulation
+      update_frame_formulation
     when :upload_formulation
       render_upload_formulation
     when :contains_poisonous_ingredients
@@ -270,6 +272,20 @@ private
       @component.update(frame_formulation: nil) unless @component.frame_formulation.nil?
     end
     render_wizard @component
+  end
+
+  def update_frame_formulation
+    if @component.update_with_context(component_params, :update_frame_formulation)
+
+      if @component.notification.notified_post_eu_exit?
+        # Redirect to "Contains poisonous ingredients?" question
+        render_wizard @component
+      else
+        redirect_to responsible_person_notification_component_trigger_question_path(@component.notification.responsible_person, @component.notification, @component, :select_ph_range)
+      end
+    else
+      render :update_frame_formulation
+    end
   end
 
   def update_contains_poisonous_ingredients

--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -278,8 +278,7 @@ private
     if @component.update_with_context(component_params, :select_frame_formulation)
 
       if @component.notification.notified_post_eu_exit?
-        # Redirect to "Contains poisonous ingredients?" question
-        render_wizard @component
+        redirect_to responsible_person_notification_component_build_path(@component.notification.responsible_person, @component.notification, @component, :contains_poisonous_ingredients)
       else
         redirect_to responsible_person_notification_component_trigger_question_path(@component.notification.responsible_person, @component.notification, @component, :select_ph_range)
       end

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -169,6 +169,14 @@ RSpec.describe ComponentBuildController, type: :controller do
       expect(assigns(:component).cmrs.first.name).to eq(cmr_name)
     end
 
+    context "when selecting a frame formulation" do
+      it "saves and redirects to the 'poisonous ingredients' question if you select an answer" do
+        post(:update, params: params.merge(id: :select_frame_formulation, component: { frame_formulation: 'skin_care_cream_lotion_gel' }))
+
+        expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :contains_poisonous_ingredients))
+      end
+    end
+
     context "when selecting whether the component contains poisonous materials" do
       it "saves and redirect to PH trigger question if you select an answer" do
         post(:update, params: params.merge(id: :contains_poisonous_ingredients, component: { contains_poisonous_ingredients: 'true' }))
@@ -193,6 +201,12 @@ RSpec.describe ComponentBuildController, type: :controller do
       it "skips special applicator and CMRs questions and redirects to contains_nanomaterials if pre-eu-exit" do
         post(:update, params: params.merge(id: :add_physical_form, component: { physical_form: "loose powder" }))
         expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, pre_eu_exit_notification, component, :contains_nanomaterials))
+      end
+
+      it "skips contains poisonous ingredients question and redirects to PH question" do
+        post(:update, params: params.merge(id: :select_frame_formulation, component: { frame_formulation: 'skin_care_cream_lotion_gel' }))
+
+        expect(response).to redirect_to(responsible_person_notification_component_trigger_question_path(responsible_person, pre_eu_exit_notification, component, :select_ph_range))
       end
     end
   end

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -175,6 +175,13 @@ RSpec.describe ComponentBuildController, type: :controller do
 
         expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, notification, component, :contains_poisonous_ingredients))
       end
+
+      it "re-renders the question with an error if you don’t select a formulation" do
+        post(:update, params: params.merge(id: :select_frame_formulation, component: { frame_formulation: '' }))
+
+        expect(response.status).to be(200)
+        expect(assigns(:component).errors[:frame_formulation]).to include("Frame formulation can not be blank")
+      end
     end
 
     context "when selecting whether the component contains poisonous materials" do


### PR DESCRIPTION
This updates the follow of the component questions so that _only_ post-Brexit products get asked whether the product contains harmful ingredients when using a frame formulation.  Pre-Brexit products skip straight to the PH question instead.

Fixes a bug introduced by https://github.com/UKGovernmentBEIS/beis-opss/pull/1331