### PR TITLE
Improve efficiency of looking up user's roles

### DIFF
--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -97,19 +97,25 @@ class User < Shared::Web::User
   end
 
   def is_psd_user?
-    has_role? :psd_user
+    roles.include?(:psd_user)
   end
 
   def is_psd_admin?
-    has_role? :psd_admin
+    roles.include?(:psd_admin)
   end
 
   def is_opss?
-    has_role? :opss_user
+    roles.include?(:opss_user)
   end
 
   def is_team_admin?
-    has_role? :team_admin
+    roles.include?(:team_admin)
+  end
+
+  def roles
+    @roles ||=
+      JSON(Shared::Web::KeycloakClient.instance.get_client_user_roles(id, access_token))
+        .map{|role| role["name"].to_sym }
   end
 
   def self.get_assignees(except: [])

--- a/psd-web/test/models/user/roles_test.rb
+++ b/psd-web/test/models/user/roles_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class UserRolesTest < ActiveSupport::TestCase
+  setup do
+    @user = User.new()
+  end
+
+  def stub_roles(roles)
+    allow(@user).to receive(:roles) { roles }
+  end
+
+  class Roles < UserRolesTest
+    setup do
+      roles = JSON.generate([
+        {
+          "name" => "opss_user",
+          "test" => "test"
+        }
+      ])
+
+      allow(@keycloak_client_instance).to receive(:get_client_user_roles) { roles }
+    end
+
+    teardown do
+      allow(@keycloak_client_instance).to receive(:get_client_user_roles).and_call_original
+    end
+
+    test "#roles retrieves the user's roles from Keycloak and caches them" do
+      3.times { @user.roles }
+      expect(@keycloak_client_instance).to have_received(:get_client_user_roles).once
+    end
+
+    test "#roles returns the user's roles" do
+      assert_equal([:opss_user], @user.roles)
+    end
+  end
+
+  class IsTeamAdmin < UserRolesTest
+    test "#is_team_admin? returns false when the user's roles don't contain it" do
+      stub_roles([:opss_user])
+      refute(@user.is_team_admin?)
+    end
+
+    test "#is_team_admin? returns true when the user's roles contains it" do
+      stub_roles([:team_admin])
+      assert(@user.is_team_admin?)
+    end
+  end
+
+  class IsOpss < UserRolesTest
+    test "#is_opss? returns false when the user's roles don't contain it" do
+      stub_roles([:team_admin])
+      refute(@user.is_opss?)
+    end
+
+    test "#is_opss? returns true when the user's roles contains it" do
+      stub_roles([:opss_user])
+      assert(@user.is_opss?)
+    end
+  end
+
+  class IsPsdAdmin < UserRolesTest
+    test "#is_psd_admin? returns false when the user's roles don't contain it" do
+      stub_roles([:team_admin])
+      refute(@user.is_psd_admin?)
+    end
+
+    test "#is_psd_admin? returns true when the user's roles contains it" do
+      stub_roles([:psd_admin])
+      assert(@user.is_psd_admin?)
+    end
+  end
+
+  class IsPsdUser < UserRolesTest
+    test "#is_psd_user? returns false when the user's roles don't contain it" do
+      stub_roles([:team_admin])
+      refute(@user.is_psd_user?)
+    end
+
+    test "#is_psd_user? returns true when the user's roles contains it" do
+      stub_roles([:psd_user])
+      assert(@user.is_psd_user?)
+    end
+  end
+end


### PR DESCRIPTION
This change means that we are able to cache the user's roles retrieved from Keycloak within a request. They are not persisted across requests, however, so further gains could be expected with more work (e.g. persist in the session).

We can see from our Scout profiling that there are multiple requests to the old `has_role?` method in each request. I've replicated the [underlying implementation](https://github.com/imagov/keycloak/blob/master/lib/keycloak.rb#L819) here.

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
