### PR TITLE
PSD: Re-add google analytics after being put in a lost content_for

### DIFF
--- a/psd-web/app/views/layouts/application.html.slim
+++ b/psd-web/app/views/layouts/application.html.slim
@@ -1,12 +1,19 @@
 doctype html
-- content_for :start_of_head
-  - if Rails.env.production?
-    script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-1"
-    javascript:
+html.govuk-template.app-html-class[lang="en"]
+  head
+    / Google Analytics
+    - if Rails.env.production?
+      script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-126364208-1"
+      javascript:
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+
         gtag('js', new Date());
         gtag('config', 'UA-126364208-1');
+
 = render "components/govuk_cookie_banner", path: help_privacy_notice_path(anchor: "cookies-policy")
 = content_for :page_title_suffix do
   |  - Product safety database - GOV.UK


### PR DESCRIPTION
While looking at the application.html for psd I notieced the google analytics tracking code was put in a content_for that wasn't used anywhere. This is why are GA isn't tracking. I think it was going to be used for a general header for multiple services, but I've reverted it to how it used to be as I'm not sure where :start_of_head was supposed to be called.
