### PR TITLE
Allow elasticsearch to be configured via env variable

### DIFF
--- a/cosmetics-web/config/elasticsearch.yml
+++ b/cosmetics-web/config/elasticsearch.yml
@@ -1,5 +1,5 @@
 default: &default
-  :url: "http://elasticsearch:9200"
+  :url: <%= ENV.fetch('ELASTICSEARCH_URL', 'http://elasticsearch:9200') %>
   :transport_options:
     :request:
       :timeout: 5


### PR DESCRIPTION
Currently the development and test environments are harcoded to expect Elasticsearch to be running at http://elasticsearch:9200. This requires entries to be added to local /etc/hosts files.

This change allows the hardcoded default to be overriden by an environment variable – eg loaded from a local .env file.

Re-opening of #1358.