### PR TITLE
Reference shared-web rather than copy it

### DIFF
--- a/cosmetics-web/Dockerfile
+++ b/cosmetics-web/Dockerfile
@@ -27,7 +27,6 @@ RUN curl -o /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/$CH
 WORKDIR /cosmetics-web
 
 COPY ./cosmetics-web .
-COPY ./shared-web ./vendor/shared-web
 
 COPY ./cosmetics-web/docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -14,7 +14,7 @@ gem "slim-rails"
 gem "strong_migrations"
 gem "wicked"
 
-gem "shared-web", path: "./vendor/shared-web"
+gem "shared-web", path: "../shared-web"
 
 
 group :development, :test do
@@ -24,5 +24,5 @@ group :development, :test do
   gem "rspec-rails"
   gem "rubocop-rspec"
 
-  gem "shared-web-dev", path: "./vendor/shared-web/dev"
+  gem "shared-web-dev", path: "../shared-web/dev"
 end

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: vendor/shared-web/dev
+  remote: ../shared-web/dev
   specs:
     shared-web-dev (1.0.0)
       brakeman (= 4.5.1)
@@ -18,7 +18,7 @@ PATH
       solargraph (= 0.33.2)
 
 PATH
-  remote: vendor/shared-web
+  remote: ../shared-web
   specs:
     shared-web (1.0.0)
       active_hash (= 2.2.1)
@@ -88,14 +88,14 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.220.0)
-    aws-sdk-core (3.68.0)
+    aws-sdk-core (3.68.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -109,7 +109,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    backport (1.1.1)
+    backport (1.1.2)
     brakeman (4.5.1)
     builder (3.2.3)
     capybara (3.24.0)
@@ -134,7 +134,7 @@ GEM
     crass (1.0.4)
     debase (0.2.2)
       debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.5)
+    debase-ruby_core_source (0.10.6)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -160,7 +160,7 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    faraday (0.16.2)
+    faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     fugit (1.3.3)
@@ -214,7 +214,7 @@ GEM
     mime-types-data (3.2019.0904)
     mimemagic (0.3.3)
     mini_magick (4.9.3)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -230,7 +230,7 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    public_suffix (3.1.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
@@ -276,14 +276,14 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.3)
-    regexp_parser (1.5.1)
+    regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    reverse_markdown (1.1.0)
+    reverse_markdown (1.3.0)
       nokogiri
     rspec-collection_matchers (1.1.3)
       rspec-expectations (>= 2.99.0.beta1)
@@ -392,7 +392,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    tins (1.20.3)
+    tins (1.21.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -411,7 +411,7 @@ GEM
     will_paginate (3.1.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.19)
+    yard (0.9.20)
 
 PLATFORMS
   ruby

--- a/cosmetics-web/package.json
+++ b/cosmetics-web/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "shared-web": "./vendor/shared-web"
+    "shared-web": "../shared-web"
   }
 }


### PR DESCRIPTION
Currently the Dockerfile copies `shared-web` into `vendor`, and both the `Gemfile` and `package.json` specifies it as a dependency within vendor.

This change removes the copy step, and just references the shared-web folder within the parent directory instead. This makes local development easier, as manual copying is no longer required to run the application without using Docker.