### PR TITLE
Provide meaningful error message when domains aren't set

### DIFF
--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => "/sidekiq"
   end
 
-  constraints DomainConstraint.new(ENV["SEARCH_HOST"] || ENV["COSMETICS_HOST"]) do
+  constraints DomainConstraint.new(ENV.fetch("SEARCH_HOST") || ENV.fetch("COSMETICS_HOST")) do
     root "landing_page#index"
 
     scope module: "poison_centres", as: "poison_centre" do
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
     end
   end
 
-  constraints DomainConstraint.new(ENV["SUBMIT_HOST"] || ENV["COSMETICS_HOST"]) do
+  constraints DomainConstraint.new(ENV.fetch("SEARCH_HOST") || ENV.fetch("COSMETICS_HOST")) do
     root "landing_page#index"
 
     resources :responsible_persons, only: %i[show] do

--- a/cosmetics-web/lib/constraints/domain_constraint.rb
+++ b/cosmetics-web/lib/constraints/domain_constraint.rb
@@ -1,5 +1,7 @@
 class DomainConstraint
   def initialize(domains)
+    raise "No domains specified" unless domains
+
     @domains = domains.split(',')
   end
 


### PR DESCRIPTION
If you try to start the application without providing the `SUBMIT_HOST` and `SEARCH_HOST` env vars, the application exists with an unhelpful error message. This fixes that.