### PR TITLE
Add extra validation rule for component pH

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -35,6 +35,8 @@ class Component < ApplicationRecord
 
   validate :maximum_ph_must_be_equal_or_above_minimum_ph, if: -> { maximum_ph.present? && minimum_ph.present? }
 
+  validate :difference_between_maximum_and_minimum_ph, if: -> { maximum_ph.present? && minimum_ph.present? }
+
   validates :minimum_ph, numericality: { message: "Enter a value of 0 or higher for minimum pH", greater_than_or_equal_to: 0 }, if: -> { minimum_ph.present? }
 
   validates :minimum_ph, numericality: { message: "Enter a value of 14 or lower for minimum pH", less_than_or_equal_to: 14 }, if: -> { minimum_ph.present? }
@@ -157,6 +159,12 @@ private
   def maximum_ph_must_be_equal_or_above_minimum_ph
     if maximum_ph < minimum_ph
       errors.add(:maximum_ph, "The maximum pH must be the same or higher than the minimum pH")
+    end
+  end
+
+  def difference_between_maximum_and_minimum_ph
+    if (maximum_ph - minimum_ph) > 1.0
+      errors.add(:maximum_ph, "The maximum pH cannot be more than 1 higher than the minimum pH")
     end
   end
 end

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -191,5 +191,13 @@ RSpec.describe Component, type: :model do
       expect(predefined_component).not_to be_valid(:ph_range)
       expect(predefined_component.errors[:maximum_ph]).to include("Enter a maximum pH")
     end
+
+    it "adds an error if difference between minimum and maximum pH is more than 1" do
+      predefined_component.minimum_ph = 2.0
+      predefined_component.maximum_ph = 3.01
+
+      expect(predefined_component).not_to be_valid(:ph_range)
+      expect(predefined_component.errors[:maximum_ph]).to include("The maximum pH cannot be more than 1 higher than the minimum pH")
+    end
   end
 end


### PR DESCRIPTION
The difference between minimum pH and maximum pH cannot be greater than 1.

Part of https://regulatorydelivery.atlassian.net/browse/COSBETA-600