### PR TITLE
Fix some legacy migrations

### DIFF
--- a/cosmetics-web/db/migrate/20190214145420_add_cpnp_basic_info_to_notification.rb
+++ b/cosmetics-web/db/migrate/20190214145420_add_cpnp_basic_info_to_notification.rb
@@ -1,10 +1,12 @@
 class AddCpnpBasicInfoToNotification < ActiveRecord::Migration[5.2]
-  safety_assured do
-    change_table :notifications, bulk: true do |t|
-      t.string :cpnp_reference
-      t.boolean :cpnp_is_imported
-      t.string :cpnp_imported_country
-      t.string :shades
+  def change
+    safety_assured do
+      change_table :notifications, bulk: true do |t|
+        t.string :cpnp_reference
+        t.boolean :cpnp_is_imported
+        t.string :cpnp_imported_country
+        t.string :shades
+      end
     end
   end
 end

--- a/cosmetics-web/db/migrate/20190220140100_add_formulation_to_components.rb
+++ b/cosmetics-web/db/migrate/20190220140100_add_formulation_to_components.rb
@@ -21,12 +21,13 @@ class AddFormulationToComponents < ActiveRecord::Migration[5.2]
 
     add_reference :range_formulas, :component, foreign_key: true, index: false
     add_index :range_formulas, :component_id, algorithm: :concurrently
-  end
 
-  safety_assured do
-    change_table :components, bulk: true do |t|
-      t.string :notification_type
-      t.string :frame_formulation
+    safety_assured do
+      change_table :components, bulk: true do |t|
+        t.string :notification_type
+        t.string :frame_formulation
+      end
     end
+
   end
 end

--- a/cosmetics-web/db/migrate/20190220140100_add_formulation_to_components.rb
+++ b/cosmetics-web/db/migrate/20190220140100_add_formulation_to_components.rb
@@ -28,6 +28,5 @@ class AddFormulationToComponents < ActiveRecord::Migration[5.2]
         t.string :frame_formulation
       end
     end
-
   end
 end

--- a/cosmetics-web/db/migrate/20190330192439_add_user_attributes.rb
+++ b/cosmetics-web/db/migrate/20190330192439_add_user_attributes.rb
@@ -1,9 +1,11 @@
 class AddUserAttributes < ActiveRecord::Migration[5.2]
-  create_table :user_attributes, id: false do |t|
-    t.uuid :user_id, primary_key: true
-    t.datetime :declaration_accepted_at
+  def change
+    create_table :user_attributes, id: false do |t|
+      t.uuid :user_id, primary_key: true
+      t.datetime :declaration_accepted_at
 
-    t.timestamps
-    t.index :user_id
+      t.timestamps
+      t.index :user_id
+    end
   end
 end


### PR DESCRIPTION
For some reason, these called `safety_assured` or `create_table` outside of a `change` block, which doesn't work.