### PR TITLE
Allow chromedriver path to be explicitly set

### DIFF
--- a/cosmetics-web/env.example
+++ b/cosmetics-web/env.example
@@ -47,3 +47,6 @@ NODE_ENV=development
 # Basic authentication
 # BASIC_AUTH_USERNAME=
 # BASIC_AUTH_PASSWORD=
+
+# Chromedriver (https://chromedriver.chromium.org)
+CHROMEDRIVER_PATH=/path/to/chromedriver

--- a/cosmetics-web/spec/system_helper.rb
+++ b/cosmetics-web/spec/system_helper.rb
@@ -7,6 +7,10 @@ ENV["HTTP_PORT"] = "3003"
 ENV["SUBMIT_HOST"] = "localhost"
 ENV["SEARCH_HOST"] = "localhost"
 
+if ENV['CHROMEDRIVER_PATH']
+  Selenium::WebDriver::Chrome::Service.driver_path=ENV.fetch('CHROMEDRIVER_PATH')
+end
+
 Capybara.server_host = ENV["HTTP_HOST"]
 Capybara.server_port = ENV["HTTP_PORT"]
 Capybara.app_host = "http://#{ENV['HTTP_HOST']}:#{ENV['HTTP_PORT']}"

--- a/cosmetics-web/spec/system_helper.rb
+++ b/cosmetics-web/spec/system_helper.rb
@@ -8,7 +8,7 @@ ENV["SUBMIT_HOST"] = "localhost"
 ENV["SEARCH_HOST"] = "localhost"
 
 if ENV['CHROMEDRIVER_PATH']
-  Selenium::WebDriver::Chrome::Service.driver_path=ENV.fetch('CHROMEDRIVER_PATH')
+  Selenium::WebDriver::Chrome::Service.driver_path = ENV.fetch('CHROMEDRIVER_PATH')
 end
 
 Capybara.server_host = ENV["HTTP_HOST"]


### PR DESCRIPTION
This allows developers to tell Selenium where they have installed the [Chromedriver](https://chromedriver.chromium.org) binary.