### PR TITLE
Don't show product ingredients to MSA users

### DIFF
--- a/cosmetics-web/app/controllers/application_controller.rb
+++ b/cosmetics-web/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :confirmation
 
+  helper_method :current_user
+
 private
 
   def authorize_user!

--- a/cosmetics-web/app/controllers/concerns/authentication_concern.rb
+++ b/cosmetics-web/app/controllers/concerns/authentication_concern.rb
@@ -28,6 +28,10 @@ module AuthenticationConcern
     User.current.access_token = access_token
   end
 
+  def current_user
+    User.current
+  end
+
   def pundit_user
     User.current
   end

--- a/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/poison_centres/notifications_controller.rb
@@ -10,6 +10,7 @@ class PoisonCentres::NotificationsController < ApplicationController
     if User.current&.poison_centre_user?
       render "show_poison_centre"
     else
+      @contact_person = @notification.responsible_person.contact_persons.first
       render "show_msa"
     end
   end

--- a/cosmetics-web/app/models/user.rb
+++ b/cosmetics-web/app/models/user.rb
@@ -66,6 +66,10 @@ class User < ActiveHash::Base
     has_role? :msa_user
   end
 
+  def can_view_product_ingredients?
+    !msa_user?
+  end
+
 private
 
   def current_user?

--- a/cosmetics-web/app/views/notifications/_component_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_component_details.html.slim
@@ -1,4 +1,4 @@
-- if current_user.can_view_product_ingredients? && component.notification.notified_post_eu_exit?
+- if component.notification.notified_post_eu_exit?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
       | Contains CMR substances
@@ -11,7 +11,6 @@
         td.govuk-table__cell
           = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
 
-- if current_user.can_view_product_ingredients?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
       | Nanomaterials
@@ -85,11 +84,14 @@ tr.govuk-table__row
                   class: "govuk-link--no-visited-state"
         - else
           | N/A
-  tr.govuk-table__row
-    th.govuk-table__header[scope="row"]
-      | Physical form
-    td.govuk-table__cell
-      = get_physical_form_name(component.physical_form)
+
+tr.govuk-table__row
+  th.govuk-table__header[scope="row"]
+    | Physical form
+  td.govuk-table__cell
+    = get_physical_form_name(component.physical_form)
+
+- if current_user.can_view_product_ingredients?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
       | Special applicator

--- a/cosmetics-web/app/views/notifications/_component_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_component_details.html.slim
@@ -1,4 +1,4 @@
-- if component.notification.notified_post_eu_exit?
+- if current_user.can_view_product_ingredients? && component.notification.notified_post_eu_exit?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
       | Contains CMR substances
@@ -11,22 +11,23 @@
         td.govuk-table__cell
           = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
 
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Nanomaterials
-  td.govuk-table__cell
-    = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
-- if component.nano_material&.nano_elements.present?
+- if current_user.can_view_product_ingredients?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Application instruction
+      | Nanomaterials
     td.govuk-table__cell
-      = get_exposure_routes_names(component.nano_material.exposure_routes)
-  tr.govuk-table__row
-    th.govuk-table__header[scope="row"]
-      | Exposure condition
-    td.govuk-table__cell
-      = get_exposure_condition_name(component.nano_material.exposure_condition)
+      = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
+  - if component.nano_material&.nano_elements.present?
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Application instruction
+      td.govuk-table__cell
+        = get_exposure_routes_names(component.nano_material.exposure_routes)
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Exposure condition
+      td.govuk-table__cell
+        = get_exposure_condition_name(component.nano_material.exposure_condition)
 
 tr.govuk-table__row
   th.govuk-table__header[scope="row"]
@@ -44,75 +45,78 @@ tr.govuk-table__row
   td.govuk-table__cell
     = get_category_name(component.sub_sub_category)
 
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Formulation given as
-  td.govuk-table__cell
-    = get_notification_type_name(component.notification_type)
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Frame formulation
-  td.govuk-table__cell
-    = get_frame_formulation_name(component.frame_formulation)
-
-- if !component.predefined?
+- if current_user.can_view_product_ingredients?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Formulation
+      | Formulation given as
     td.govuk-table__cell
-      - if component.exact? && component.exact_formulas.present?
-        = render "none_or_bullet_list", entities_list: format_exact_formulas(component.exact_formulas),
-                key_name: :inci_name, value_name: :quantity
-      - elsif component.range? && component.range_formulas.present?
-        = render "none_or_bullet_list", entities_list: format_range_formulas(component.range_formulas),
-                key_name: :inci_name, value_name: :range
-      - elsif component.formulation_file.attached?
-        - if component.formulation_file.metadata["safe"]
-          = link_to component.formulation_file.filename, url_for(component.formulation_file)
-        - else
-          = "Processing file #{component.formulation_file.filename} ..."
-          br
-          = link_to "Refresh",
-                  edit_responsible_person_notification_path(@responsible_person, @notification),
+      = get_notification_type_name(component.notification_type)
+  tr.govuk-table__row
+    th.govuk-table__header[scope="row"]
+      | Frame formulation
+    td.govuk-table__cell
+      = get_frame_formulation_name(component.frame_formulation)
+
+- if current_user.can_view_product_ingredients?
+  - if !component.predefined?
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Formulation
+      td.govuk-table__cell
+        - if component.exact? && component.exact_formulas.present?
+          = render "none_or_bullet_list", entities_list: format_exact_formulas(component.exact_formulas),
+                  key_name: :inci_name, value_name: :quantity
+        - elsif component.range? && component.range_formulas.present?
+          = render "none_or_bullet_list", entities_list: format_range_formulas(component.range_formulas),
+                  key_name: :inci_name, value_name: :range
+        - elsif component.formulation_file.attached?
+          - if component.formulation_file.metadata["safe"]
+            = link_to component.formulation_file.filename, url_for(component.formulation_file)
+          - else
+            = "Processing file #{component.formulation_file.filename} ..."
+            br
+            = link_to "Refresh",
+                    edit_responsible_person_notification_path(@responsible_person, @notification),
+                    class: "govuk-link--no-visited-state"
+        - elsif allow_edits
+          = link_to "Add formulation document",
+                  new_responsible_person_notification_component_formulation_path(@notification.responsible_person,
+                          @notification, component),
                   class: "govuk-link--no-visited-state"
-      - elsif allow_edits
-        = link_to "Add formulation document",
-                new_responsible_person_notification_component_formulation_path(@notification.responsible_person,
-                        @notification, component),
-                class: "govuk-link--no-visited-state"
-      - else
-        | N/A
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Physical form
-  td.govuk-table__cell
-    = get_physical_form_name(component.physical_form)
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Special applicator
-  td.govuk-table__cell
-    = component.special_applicator.present? ? "Yes" : "No"
-- if component.special_applicator.present?
+        - else
+          | N/A
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Applicator type
+      | Physical form
     td.govuk-table__cell
-      = component_special_applicator_name(component)
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Acute poisoning information
-  td.govuk-table__cell
-    = component.acute_poisoning_info
-
-- if component.predefined?
+      = get_physical_form_name(component.physical_form)
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Contains poisonous ingredients
+      | Special applicator
     td.govuk-table__cell
-      = component.contains_poisonous_ingredients.present? ? "Yes" : "No"
+      = component.special_applicator.present? ? "Yes" : "No"
+  - if component.special_applicator.present?
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Applicator type
+      td.govuk-table__cell
+        = component_special_applicator_name(component)
+  tr.govuk-table__row
+    th.govuk-table__header[scope="row"]
+      | Acute poisoning information
+    td.govuk-table__cell
+      = component.acute_poisoning_info
 
-- if component.trigger_questions
-  = render "notifications/ph", component: component
-  - component.trigger_questions.each do |question|
-    - unless question.question == "please_indicate_the_ph"
-      = render "notifications/trigger_question_details", trigger_question: question, display_not_applicable: true
+- if current_user.can_view_product_ingredients?
+  - if component.predefined?
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Contains poisonous ingredients
+      td.govuk-table__cell
+        = component.contains_poisonous_ingredients.present? ? "Yes" : "No"
+
+  - if component.trigger_questions
+    = render "notifications/ph", component: component
+    - component.trigger_questions.each do |question|
+      - unless question.question == "please_indicate_the_ph"
+        = render "notifications/trigger_question_details", trigger_question: question, display_not_applicable: true

--- a/cosmetics-web/app/views/notifications/_product_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_product_details.html.slim
@@ -63,11 +63,6 @@ table.govuk-table.check-your-answers-table#product-table
           = display_full_month_date notification.cpnp_notification_date
     tr.govuk-table__row
       th.govuk-table__header
-        | Still on the market
-      td.govuk-table__cell
-        = notification.still_on_the_market ? "Yes" : "No"
-    tr.govuk-table__row
-      th.govuk-table__header
         | Are the components mixed?
       td.govuk-table__cell
         = notification.components_are_mixed ? "Yes" : "No"

--- a/cosmetics-web/app/views/notifications/_product_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_product_details.html.slim
@@ -19,12 +19,12 @@ table.govuk-table.check-your-answers-table#product-table
           | Imported
         td.govuk-table__cell
           = product_imported?(notification)
-    - if product_imported?(notification) == "Yes"
-      tr.govuk-table__row
-        th.govuk-table__header[scope="row"]
-          | Imported from
-        td.govuk-table__cell
-          = product_import_country(notification)
+      - if product_imported?(notification) == "Yes"
+        tr.govuk-table__row
+          th.govuk-table__header[scope="row"]
+            | Imported from
+          td.govuk-table__cell
+            = product_import_country(notification)
     - if notification.notified_post_eu_exit?
       tr.govuk-table__row
         th.govuk-table__header
@@ -71,13 +71,13 @@ table.govuk-table.check-your-answers-table#product-table
         | Are the components mixed?
       td.govuk-table__cell
         = notification.components_are_mixed ? "Yes" : "No"
-    - if notification.ph_min_value.present?
+    - if current_user.can_view_product_ingredients? && notification.ph_min_value.present?
       tr.govuk-table__row
         th.govuk-table__header
           | Minimum pH value
         td.govuk-table__cell
           = notification.ph_min_value
-    - if notification.ph_max_value.present?
+    - if current_user.can_view_product_ingredients? && notification.ph_max_value.present?
       tr.govuk-table__row
         th.govuk-table__header
           | Maximum pH value

--- a/cosmetics-web/app/views/notifications/_product_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_product_details.html.slim
@@ -13,11 +13,12 @@ table.govuk-table.check-your-answers-table#product-table
           | Internal reference number
         td.govuk-table__cell
           = notification.industry_reference
-    tr.govuk-table__row
-      th.govuk-table__header[scope="row"]
-        | Imported
-      td.govuk-table__cell
-        = product_imported?(notification)
+    - if current_user.can_view_product_ingredients?
+      tr.govuk-table__row
+        th.govuk-table__header[scope="row"]
+          | Imported
+        td.govuk-table__cell
+          = product_imported?(notification)
     - if product_imported?(notification) == "Yes"
       tr.govuk-table__row
         th.govuk-table__header[scope="row"]

--- a/cosmetics-web/app/views/notifications/_trigger_question_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_trigger_question_details.html.slim
@@ -1,5 +1,5 @@
 - elements = trigger_question.trigger_question_elements
-tr.govuk-table__row
+tr.govuk-table__row.trigger-question
   - if trigger_question.applicable? || display_not_applicable
     th.govuk-table__header[scope="row"]
       = get_trigger_rules_short_question_name(trigger_question.question)

--- a/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.slim
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.slim
@@ -6,5 +6,5 @@
     h1.govuk-heading-xl
       = @notification.product_name
     = render "notifications/responsible_person_details", responsible_person: @notification.responsible_person
-    = render "notifications/contact_person_overview", contact_person: @notification.responsible_person.contact_persons.first
+    = render "notifications/contact_person_overview", contact_person: @contact_person
     = render "notifications/product_details", notification: @notification, allow_edits: false

--- a/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.slim
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_msa.html.slim
@@ -6,4 +6,5 @@
     h1.govuk-heading-xl
       = @notification.product_name
     = render "notifications/responsible_person_details", responsible_person: @notification.responsible_person
+    = render "notifications/contact_person_overview", contact_person: @notification.responsible_person.contact_persons.first
     = render "notifications/product_details", notification: @notification, allow_edits: false

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -105,40 +105,56 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
         expect(response).to render_template("notifications/show_msa")
       end
 
-      describe "product ingredients" do
+      describe "displayed information" do
         let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
         let(:responsible_person) { create(:responsible_person) }
-        let(:notification) { create(:notification, :imported, :registered, components: [component], responsible_person: responsible_person) }
+        let(:notification) { create(:notification, :imported, :registered, :ph_values, components: [component], responsible_person: responsible_person) }
 
         render_views
 
+        it "renders contact person overview" do
+          expect(response.body).to match(/Contact person/)
+        end
+
         it "does not render product imported status" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Imported<\/th>/)
+          expect(response.body).not_to match(/Imported/)
         end
 
         it "does not render component formulations" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Formulation given as<\/th>/)
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Frame formulation<\/th>/)
+          expect(response.body).not_to match(/Formulation given as/)
+          expect(response.body).not_to match(/Frame formulation/)
         end
 
         it "does not render acute poisoning info" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Acute poisoning information<\/th>/)
+          expect(response.body).not_to match(/Acute poisoning information/)
         end
 
         it "does not render poisonous ingredients" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Contains poisonous ingredients<\/th>/)
+          expect(response.body).not_to match(/Contains poisonous ingredients/)
         end
 
         it "does not render trigger questions" do
           expect(response.body).not_to match(/<tr class="govuk-table__row trigger-question">/)
         end
 
-        it "does not render CMR substances" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Contains CMR substances<\/th>/)
+        it "does not render minimum pH" do
+          expect(response.body).not_to match(/Minimum pH value/)
         end
 
-        it "does not render nanomaterials" do
-          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Nanomaterials<\/th>/)
+        it "does not render Maximum pH" do
+          expect(response.body).not_to match(/Maximum pH value/)
+        end
+
+        it "renders CMR substances" do
+          expect(response.body).to match(/Contains CMR substances/)
+        end
+
+        it "renders nanomaterials" do
+          expect(response.body).to match(/Nanomaterials/)
+        end
+
+        it "renders physical form" do
+          expect(response.body).to match(/Physical form/)
         end
       end
     end

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
     describe "GET #show" do
       let(:notification) { rp_1_notifications.first }
 
+      before { get :show, params: { reference_number: notification.reference_number } }
+
       it "assigns the correct notification" do
-        get :show, params: { reference_number: notification.reference_number }
         expect(assigns(:notification)).to eq(notification)
       end
 
       it "renders the show template" do
-        get :show, params: { reference_number: notification.reference_number }
         expect(response).to render_template("notifications/show_poison_centre")
       end
     end
@@ -99,9 +99,47 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
     describe "GET #show" do
       let(:notification) { rp_1_notifications.first }
 
+      before { get :show, params: { reference_number: notification.reference_number } }
+
       it "renders the show template" do
-        get :show, params: { reference_number: notification.reference_number }
         expect(response).to render_template("notifications/show_msa")
+      end
+
+      describe "product ingredients" do
+        let(:component) { create(:component, :with_poisonous_ingredients, :with_trigger_questions) }
+        let(:responsible_person) { create(:responsible_person) }
+        let(:notification) { create(:notification, :imported, :registered, components: [component], responsible_person: responsible_person) }
+
+        render_views
+
+        it "does not render product imported status" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Imported<\/th>/)
+        end
+
+        it "does not render component formulations" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Formulation given as<\/th>/)
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Frame formulation<\/th>/)
+        end
+
+        it "does not render acute poisoning info" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Acute poisoning information<\/th>/)
+        end
+
+        it "does not render poisonous ingredients" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Contains poisonous ingredients<\/th>/)
+        end
+
+        it "does not render trigger questions" do
+          expect(response.body).not_to match(/<tr class="govuk-table__row trigger-question">/)
+        end
+
+        it "does not render CMR substances" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Contains CMR substances<\/th>/)
+        end
+
+        it "does not render nanomaterials" do
+          expect(response.body).not_to match(/<th class="govuk-table__header" scope="row">Nanomaterials<\/th>/)
+        end
       end
     end
   end

--- a/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/poison_centres/notifications_controller_spec.rb
@@ -145,6 +145,10 @@ RSpec.describe PoisonCentres::NotificationsController, type: :controller do
           expect(response.body).not_to match(/Maximum pH value/)
         end
 
+        it "does not render still on the market" do
+          expect(response.body).not_to match(/Still on the market/)
+        end
+
         it "renders CMR substances" do
           expect(response.body).to match(/Contains CMR substances/)
         end

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -8,5 +8,13 @@ FactoryBot.define do
     factory :exact_component do
       notification_type { "exact" }
     end
+
+    trait :with_poisonous_ingredients do
+      contains_poisonous_ingredients { true }
+    end
+
+    trait :with_trigger_questions do
+      trigger_questions { build_list :trigger_question, 2 }
+    end
   end
 end

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -25,5 +25,10 @@ FactoryBot.define do
     trait :registered do
       state { :notification_complete }
     end
+
+    trait :ph_values do
+      ph_min_value { 4 }
+      ph_max_value { 8 }
+    end
   end
 end

--- a/cosmetics-web/spec/factories/notification.rb
+++ b/cosmetics-web/spec/factories/notification.rb
@@ -17,5 +17,13 @@ FactoryBot.define do
     factory :pre_eu_exit_notification do
       was_notified_before_eu_exit { true }
     end
+
+    trait :imported do
+      import_country { "country:FR" }
+    end
+
+    trait :registered do
+      state { :notification_complete }
+    end
   end
 end

--- a/cosmetics-web/spec/models/user_spec.rb
+++ b/cosmetics-web/spec/models/user_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  subject(:user) { described_class.new(id: 123) }
+
+  describe "#can_view_product_ingredients?" do
+    context "when MSA user" do
+      before { allow(KeycloakClient.instance).to receive(:has_role?).with(user.id, :msa_user, nil).and_return(true) }
+
+      it "returns false" do
+        expect(user).not_to be_can_view_product_ingredients
+      end
+    end
+
+    context "when not an MSA user" do
+      before { allow(KeycloakClient.instance).to receive(:has_role?).with(user.id, :msa_user, nil).and_return(false) }
+
+      it "returns true" do
+        expect(user).to be_can_view_product_ingredients
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://regulatorydelivery.atlassian.net/browse/COSBETA-631

This ensures that market surveillance authority users can't view product ingredients.

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/408371/67103516-33b31c80-f1bd-11e9-9e9c-6145703deccc.gif)

As demonstrated by the video, the user who created the notification can still see them.

Poison centre users view the product on a different set of templates which haven't been altered here.

The diff on the view templates is a bit over the top; I mostly just added indentation beneath the new conditionals. Slim 🤷‍♂ 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)

![screencapture-search-cosmetics-3002-notifications-54252960-2019-10-21-10_31_42](https://user-images.githubusercontent.com/408371/67193919-0e592500-f3ee-11e9-8f99-62b76dbda38c.png)