### PR TITLE
Ability to create a separate instance of redis

### DIFF
--- a/cosmetics-web/config/redis.yml
+++ b/cosmetics-web/config/redis.yml
@@ -8,4 +8,4 @@ test:
   <<: *default
 
 production:
-  url: <%= ENV["VCAP_SERVICES"] && CF::App::Credentials.find_by_service_name("cosmetics-queue")["uri"] %>
+  url: <%= ENV["VCAP_SERVICES"] && CF::App::Credentials.find_by_service_label("redis")["uri"] %>

--- a/cosmetics-web/manifest.review.yml
+++ b/cosmetics-web/manifest.review.yml
@@ -19,7 +19,7 @@ applications:
   services:
     - ((cosmetics-web-database))
     - cosmetics-elasticsearch
-    - cosmetics-queue
+    - ((cosmetics-redis-service))
     - opss-log-drain
     - cosmetics-aws-env
     - cosmetics-auth-env

--- a/cosmetics-worker/manifest.review.worker.yml
+++ b/cosmetics-worker/manifest.review.worker.yml
@@ -18,7 +18,7 @@ applications:
   services:
     - ((cosmetics-web-database))
     - cosmetics-elasticsearch
-    - cosmetics-queue
+    - ((cosmetics-redis-service))
     - opss-log-drain
     - antivirus-auth-env
     - cosmetics-aws-env


### PR DESCRIPTION
This allows developers to create a new redis service, rather than re-using a shared one, when deploying review apps.