### PR TITLE
Ask users CMR questions regardless of pre or post brexit

### DIFF
--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -183,11 +183,7 @@ private
 
   def render_add_cmrs
     if @component.update_with_context(component_params, step)
-      if @component.notification.was_notified_before_eu_exit?
-        jump_to(next_step(:contains_cmrs))
-      else
-        render_wizard @component
-      end
+      render_wizard @component
     else
       create_required_cmrs
       render step

--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -183,7 +183,11 @@ private
 
   def render_add_cmrs
     if @component.update_with_context(component_params, step)
-      render_wizard @component
+      if @component.notification.was_notified_before_eu_exit?
+        jump_to(next_step(:contains_cmrs))
+      else
+        render_wizard @component
+      end
     else
       create_required_cmrs
       render step
@@ -343,7 +347,7 @@ private
   end
 
   def post_eu_exit_steps
-    %i[add_cmrs contains_cmrs contains_special_applicator select_special_applicator_type]
+    %i[contains_special_applicator select_special_applicator_type]
   end
 
   def model

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -269,9 +269,9 @@ RSpec.describe ComponentBuildController, type: :controller do
         params.merge!(notification_reference_number: pre_eu_exit_notification.reference_number)
       end
 
-      it "skips special applicator and CMRs questions and redirects to contains_nanomaterials if pre-eu-exit" do
+      it "redirects to contains_cmrs if pre-eu-exit" do
         post(:update, params: params.merge(id: :add_physical_form, component: { physical_form: "loose powder" }))
-        expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, pre_eu_exit_notification, component, :contains_nanomaterials))
+        expect(response).to redirect_to(responsible_person_notification_component_build_path(responsible_person, pre_eu_exit_notification, component, :contains_cmrs))
       end
 
       it "skips contains poisonous ingredients question and redirects to PH question" do


### PR DESCRIPTION
## Description
Regardless of whether a user is notifying on a product pre or post brexit they should be asked whether their product contains CMRs.

This PR changes the pre-brexit journey to make sure that this now happens.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.