### PR TITLE
Fetch github gem repo via https

### DIFF
--- a/cosmetics-web/Gemfile
+++ b/cosmetics-web/Gemfile
@@ -33,7 +33,7 @@ gem "strong_migrations"
 gem "webpacker", "4.0.7"
 gem "wicked"
 
-gem "govuk-design-system-rails", github: "UKGovernmentBEIS/govuk-design-system-rails", tag: "0.0.1", require: "govuk_design_system"
+gem "govuk-design-system-rails", git: "https://github.com/UKGovernmentBEIS/govuk-design-system-rails", tag: "0.0.1", require: "govuk_design_system"
 
 group :development, :test do
   gem "brakeman", "4.5.1"

--- a/cosmetics-web/Gemfile.lock
+++ b/cosmetics-web/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/UKGovernmentBEIS/govuk-design-system-rails.git
+  remote: https://github.com/UKGovernmentBEIS/govuk-design-system-rails
   revision: 24cc0682ebd5c0e9dd003c830b099315f9b9c332
   tag: 0.0.1
   specs:


### PR DESCRIPTION
This avoids the warning:

> The git source `git://github.com/UKGovernmentBEIS/govuk-design-system-rails.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.

...appearing in the build logs, to reduce the noise (and improve security).