### PR TITLE
Skip product image upload page for pre-Brexit notifications

### DIFF
--- a/cosmetics-web/app/controllers/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/notification_build_controller.rb
@@ -156,7 +156,14 @@ private
       new_component = invalid_multicomponents.empty? ? @notification.components.create : invalid_multicomponents.first
       redirect_to new_responsible_person_notification_component_build_path(@notification.responsible_person, @notification, new_component)
     elsif @notification.get_valid_multicomponents.length > 1
-      render_wizard @notification
+
+      if @notification.was_notified_before_eu_exit?
+        # Product images aren’t needed for pre-Brexit notifications,
+        # so redirect to Check your answers page instead
+        redirect_to edit_responsible_person_notification_path(@notification.responsible_person, @notification)
+      else
+        render_wizard @notification
+      end
     else
       render step
     end

--- a/cosmetics-web/app/controllers/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/trigger_questions_controller.rb
@@ -29,8 +29,8 @@ private
   def finish_wizard_path
     if @component.notification.is_multicomponent?
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_new_component)
-   elsif @component.notification.was_notified_before_eu_exit?
-     edit_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
+    elsif @component.notification.was_notified_before_eu_exit?
+      edit_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
     else
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_product_image)
     end

--- a/cosmetics-web/app/controllers/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/trigger_questions_controller.rb
@@ -46,6 +46,7 @@ private
     return re_render_step unless @component.update_with_context(ph_param, :ph)
 
     if @component.ph_range_not_required?
+      update_notification_state
       redirect_to finish_wizard_path
     else
       redirect_to wizard_path(:ph)
@@ -54,9 +55,16 @@ private
 
   def update_component_ph
     if @component.update_with_context(component_ph_attributes, :ph_range)
+      update_notification_state
       redirect_to finish_wizard_path
     else
       re_render_step
+    end
+  end
+
+  def update_notification_state
+    if @component.notification.was_notified_before_eu_exit?
+      @component.notification.components_completed_and_product_image_not_needed!
     end
   end
 

--- a/cosmetics-web/app/controllers/trigger_questions_controller.rb
+++ b/cosmetics-web/app/controllers/trigger_questions_controller.rb
@@ -29,6 +29,8 @@ private
   def finish_wizard_path
     if @component.notification.is_multicomponent?
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_new_component)
+   elsif @component.notification.was_notified_before_eu_exit?
+     edit_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
     else
       responsible_person_notification_build_path(@component.notification.responsible_person, @component.notification, :add_product_image)
     end

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -82,6 +82,10 @@ class Notification < ApplicationRecord
       transitions from: :components_complete, to: :draft_complete
     end
 
+    event :components_completed_and_product_image_not_needed do
+      transitions from: :components_complete, to: :draft_complete
+    end
+
     event :notification_file_parsed do
       transitions from: :empty, to: :notification_file_imported, guard: :formulation_required?
       transitions from: :empty, to: :draft_complete

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -183,6 +183,36 @@ RSpec.describe NotificationBuildController, type: :controller do
         expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, pre_eu_exit_notification, :single_or_multi_component))
       end
     end
+
+    context "when pressing 'Continue' from the List of components page" do
+      before do
+        post(:update, params: params.merge(id: :add_new_component, notification_reference_number: completed_notification.reference_number, commit: "continue"))
+      end
+
+      context "when only 1 valid component has been added" do
+        let(:completed_notification) { create(:notification, responsible_person: responsible_person, components: [create(:component, :with_name)]) }
+
+        it "re-renders the page" do
+          expect(response.status).to be(200)
+        end
+      end
+
+      context "when the product was notified pre-Brexit and has 2 valid component" do
+        let(:completed_notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person, components: [create(:component, :with_name), create(:component, :with_name)]) }
+
+        it "redirects to the add 'check your answers' page" do
+          expect(response).to redirect_to(edit_responsible_person_notification_path(responsible_person, completed_notification.reference_number))
+        end
+      end
+
+      context "when the product was notified post-Brexit and has 2 valid component" do
+        let(:completed_notification) { create(:notification, responsible_person: responsible_person, components: [create(:component, :with_name), create(:component, :with_name)]) }
+
+        it "redirects to the add product image page" do
+          expect(response).to redirect_to(responsible_person_notification_build_path(responsible_person, completed_notification.reference_number, :add_product_image))
+        end
+      end
+    end
   end
 
 private

--- a/cosmetics-web/spec/factories/component.rb
+++ b/cosmetics-web/spec/factories/component.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     trait :with_trigger_questions do
       trigger_questions { build_list :trigger_question, 2 }
     end
+
+    trait :with_name do
+      name { "a component" }
+    end
   end
 end

--- a/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
+++ b/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
@@ -106,8 +106,18 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.ph).to eql('not_applicable')
         end
 
-        it "redirects to the add product image page" do
-          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+        context "when the notification was first notified pre-Brexit" do
+          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person) }
+
+          it "redirects to the add check your answers page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
+          end
+        end
+
+        context "when the notification was first notified post-Brexit" do
+          it "redirects to the add product image page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+          end
         end
       end
 
@@ -120,8 +130,18 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.ph).to eql('between_3_and_10')
         end
 
-        it "redirects to the add product image page" do
-          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+        context "when the notification was first notified pre-Brexit" do
+          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person) }
+
+          it "redirects to the add check your answers page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
+          end
+        end
+
+        context "when the notification was first notified post-Brexit" do
+          it "redirects to the add product image page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+          end
         end
       end
 
@@ -182,8 +202,18 @@ RSpec.describe "Trigger questions", type: :request do
           expect(component.reload.maximum_ph).to be(2.3)
         end
 
-        it "redirects to the 'Upload an image of the product label' page" do
-          expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+        context "when the notification was first notified pre-Brexit" do
+          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person) }
+
+          it "redirects to the add check your answers page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
+          end
+        end
+
+        context "when the notification was first notified post-Brexit" do
+          it "redirects to the add product image page" do
+            expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/build/add_product_image")
+          end
         end
       end
     end

--- a/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
+++ b/cosmetics-web/spec/requests/trigger_questions_requests_spec.rb
@@ -107,10 +107,14 @@ RSpec.describe "Trigger questions", type: :request do
         end
 
         context "when the notification was first notified pre-Brexit" do
-          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person) }
+          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person, state: 'components_complete') }
 
           it "redirects to the add check your answers page" do
             expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
+          end
+
+          it "updates the notification state to draft_complete" do
+            expect(notification.reload.state).to eql('draft_complete')
           end
         end
 
@@ -203,10 +207,14 @@ RSpec.describe "Trigger questions", type: :request do
         end
 
         context "when the notification was first notified pre-Brexit" do
-          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person) }
+          let(:notification) { create(:pre_eu_exit_notification, responsible_person: responsible_person, state: 'components_complete') }
 
           it "redirects to the add check your answers page" do
             expect(response).to redirect_to("/responsible_persons/#{responsible_person.id}/notifications/#{notification.reference_number}/edit")
+          end
+
+          it "updates the notification state to draft_complete" do
+            expect(notification.reload.state).to eql('draft_complete')
           end
         end
 

--- a/maintenance/yarn.lock
+++ b/maintenance/yarn.lock
@@ -1388,9 +1388,9 @@ minizlib@^1.1.1:
     minipass "^2.2.1"
 
 mixin-deep@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
-  integrity sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
+  integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"


### PR DESCRIPTION
Products notified before Brexit don’t need to upload a product image.

https://regulatorydelivery.atlassian.net/jira/software/projects/COSBETA/boards/24?selectedIssue=COSBETA-700

Review app: https://cosmetics-pr-1426-submit-web.london.cloudapps.digital