### PR TITLE
Use Pull Request ID instead of branch name

### DIFF
--- a/infrastructure/ci/deploy-review-app.sh
+++ b/infrastructure/ci/deploy-review-app.sh
@@ -10,9 +10,9 @@ set -ex
 ./infrastructure/ci/install-cf.sh
 cf login -a api.london.cloud.service.gov.uk -u $CF_USERNAME -p $CF_PASSWORD -o 'beis-opss' -s $SPACE
 export DB_VERSION=`cat cosmetics-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
-export REVIEW_INSTANCE_NAME=$TRAVIS_PULL_REQUEST_BRANCH
+export REVIEW_INSTANCE_NAME=pr-$TRAVIS_PULL_REQUEST
 export DB_NAME=cosmetics-db-$DB_VERSION
 # redis will be new for each review app
-export REDIS_NAME=cosmetics-review-redis-$TRAVIS_PULL_REQUEST_BRANCH
+export REDIS_NAME=cosmetics-review-redis-$TRAVIS_PULL_REQUEST
 ./$COMPONENT/deploy-review.sh
 cf logout


### PR DESCRIPTION
This will avoid errors when the branch name contains characters not allowed for the service instance name or the Redis database name.