### PR TITLE
Don't rescue from all errors when parsing CPNP files

### DIFF
--- a/cosmetics-web/app/analyzers/read_data_analyzer.rb
+++ b/cosmetics-web/app/analyzers/read_data_analyzer.rb
@@ -84,9 +84,6 @@ private
     rescue CpnpFileNotifiedPostBrexitError => e
       Sidekiq.logger.error e.message
       @notification_file.update(upload_error: :post_brexit_date)
-    rescue StandardError => e
-      Sidekiq.logger.error "StandardError: #{e.message}\n #{e.backtrace}"
-      @notification_file.update(upload_error: :unknown_error)
     end
     # rubocop:enable Metrics/BlockLength
   end


### PR DESCRIPTION
Currently if there are _any_ errors when parsing the CPNP files, including syntax errors in our code, we rescue from them and just add an "uknown_error", which displays as:

> Try again or manually enter the production notification data

This means that Sentry isn’t notified of the exception.  By removing this, we'll be alerted to these errors earlier, and can then either fix them or add more specific errors that will make more sense to users.