### PR TITLE
Use `cf auth` instead of `cf login`

### DIFF
--- a/infrastructure/ci/cleanup-review-app.sh
+++ b/infrastructure/ci/cleanup-review-app.sh
@@ -3,7 +3,9 @@ set -x
 number=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss/commits/$TRAVIS_COMMIT/pulls | jq '.[0] | .number'`
 
 ./infrastructure/ci/install-cf.sh
-cf login -a api.london.cloud.service.gov.uk -u $CF_USERNAME -p $CF_PASSWORD -o 'beis-opss' -s $SPACE
+cf api api.london.cloud.service.gov.uk
+cf auth
+cf target -o 'beis-opss' -s $SPACE
 cf delete -f cosmetics-pr-$number-web
 cf delete -f cosmetics-pr-$number-worker
 cf delete-service -f cosmetics-review-redis-$number

--- a/infrastructure/ci/deploy-if-changed.sh
+++ b/infrastructure/ci/deploy-if-changed.sh
@@ -9,7 +9,9 @@ set -ex
 
 if [[ $(./infrastructure/ci/get-changed-components.sh) =~ ((^| )$COMPONENT($| )) ]]; then
     ./infrastructure/ci/install-cf.sh
-    cf login -a api.london.cloud.service.gov.uk -u $CF_USERNAME -p $CF_PASSWORD -o 'beis-opss' -s $SPACE
+    cf api api.london.cloud.service.gov.uk
+    cf auth
+    cf target -o 'beis-opss' -s $SPACE
     ./$COMPONENT/deploy.sh
     cf logout
 

--- a/infrastructure/ci/deploy-review-app.sh
+++ b/infrastructure/ci/deploy-review-app.sh
@@ -8,7 +8,9 @@ set -ex
 # SPACE: the space to which you want to deploy
 
 ./infrastructure/ci/install-cf.sh
-cf login -a api.london.cloud.service.gov.uk -u $CF_USERNAME -p $CF_PASSWORD -o 'beis-opss' -s $SPACE
+cf api api.london.cloud.service.gov.uk
+cf auth
+cf target -o 'beis-opss' -s $SPACE
 export DB_VERSION=`cat cosmetics-web/db/schema.rb | grep 'ActiveRecord::Schema.define' | grep -o '[0-9_]\+'`
 export REVIEW_INSTANCE_NAME=pr-$TRAVIS_PULL_REQUEST
 export DB_NAME=cosmetics-db-$DB_VERSION


### PR DESCRIPTION
## Description
This PR is raised following a conversation with @frankieroberto 

`cf login` is intended for use interactively, by humans. Whilst it can be used
in a non-interactive way, it requires the credentials to be exposed in
plaintext as part of the command being run.

Instead, `cf auth` [1] should be used when working with CF in an automated
fashion. It avoids the problems of `cf login` by sourcing its credentials from
the `CF_USERNAME` and `CF_PASSWORD` environment variables.

This commit replaces `cf login` with `cf auth` in every place I could find.

[1] https://cli.cloudfoundry.org/en-US/cf/auth.html

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
