### PR TITLE
Allow Sidekiq queue name to be specified - especially to segregate review apps

### DIFF
--- a/cosmetics-web/app/jobs/application_job.rb
+++ b/cosmetics-web/app/jobs/application_job.rb
@@ -1,3 +1,3 @@
 class ApplicationJob < ActiveJob::Base
-  queue_as :cosmetics
+  queue_as ENV["SIDEKIQ_QUEUE"] || "cosmetics"
 end

--- a/cosmetics-web/config/application.rb
+++ b/cosmetics-web/config/application.rb
@@ -31,7 +31,7 @@ module Cosmetics
     config.eager_load_paths << Rails.root.join("presenters")
 
     config.active_job.queue_adapter = :sidekiq
-    config.action_mailer.deliver_later_queue_name = 'cosmetics-mailers'
+    config.action_mailer.deliver_later_queue_name = "#{ENV['SIDEKIQ_QUEUE'] || 'cosmetics'}-mailers"
 
     # Set the request timeout in seconds. The default set by Slowpoke is 15 seconds.
     # Use a longer timeout on development environments to allow for asset compilation.

--- a/cosmetics-web/config/initializers/sidekiq.rb
+++ b/cosmetics-web/config/initializers/sidekiq.rb
@@ -1,9 +1,9 @@
 def create_log_db_metrics_job
   log_db_metrics_job = Sidekiq::Cron::Job.new(
-    name: 'log db metrics, every day at 1 am',
+    name: "#{ENV['SIDEKIQ_QUEUE'] || 'cosmetics'}: log db metrics, every day at 1 am",
     cron: '0 1 * * *',
     class: 'LogDbMetricsJob',
-    queue: 'cosmetics'
+    queue: ENV["SIDEKIQ_QUEUE"] || "cosmetics"
   )
   unless log_db_metrics_job.save
     Rails.logger.error "***** WARNING - Log DB metrics job was not saved! *****"

--- a/cosmetics-web/config/initializers/storage.rb
+++ b/cosmetics-web/config/initializers/storage.rb
@@ -10,4 +10,4 @@ end
 Rails.application.config.document_analyzers.append ReadDataAnalyzer
 # MasterAnalyzer is the only one that we pass to active_storage
 Rails.application.config.active_storage.analyzers = [MasterAnalyzer]
-Rails.application.config.active_storage.queue = :cosmetics
+Rails.application.config.active_storage.queue = ENV["SIDEKIQ_QUEUE"] || "cosmetics"

--- a/cosmetics-web/config/sidekiq.yml
+++ b/cosmetics-web/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
 :concurrency: 10
 :queues:
-  - cosmetics
-  - cosmetics-mailers
+  - <%= ENV['SIDEKIQ_QUEUE'] || "cosmetics" %>
+  - <%= ENV['SIDEKIQ_QUEUE'] || "cosmetics" %>-mailers

--- a/cosmetics-web/deploy-review.sh
+++ b/cosmetics-web/deploy-review.sh
@@ -52,6 +52,9 @@ cf push $WORKER -f $MANIFEST_FILE_WORKER --no-start --var cosmetics-instance-nam
 cf set-env $WEB SENTRY_CURRENT_ENV $REVIEW_INSTANCE_NAME
 cf set-env $WORKER SENTRY_CURRENT_ENV $REVIEW_INSTANCE_NAME
 
+cf set-env $WEB SIDEKIQ_QUEUE "$INSTANCE_NAME"
+cf set-env $WORKER SIDEKIQ_QUEUE "$INSTANCE_NAME"
+
 cf start $WEB
 cf start $WORKER
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Port of https://github.com/UKGovernmentBEIS/beis-opss-psd/pull/62.

Currently all review app workers are sharing the same queue, so it is not possible to segregate them.

An immediately obvious example would be if you create a new scheduled job another review app worker can pick it up, but immediately fail because it doesn't have that job class available.

Other problems could occur when app logic is modified and it will not be possible to tell which review app processed the job.

This change separates the queues based on the review instance name, e.g. `pr-XX`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
