### PR TITLE
Make sure bulk upload caters for nano-material that is not notified the UK

### DIFF
--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -40,6 +40,6 @@ class NanoElement < ApplicationRecord
   end
 
   def usage_confirmed?
-    (confirm_usage.nil? || confirm_usage == "no")
+    confirm_usage.nil?
   end
 end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -15,8 +15,8 @@ class NanoElement < ApplicationRecord
 
   def incomplete?
     purposes.blank? ||
-      (non_standard? && notified_toxicology?) ||
-      (standard? && restrictions_confirmed?)
+      (non_standard? && toxicology_incomplete?) ||
+      (standard? && restrictions_confirmed_incomplete?)
   end
 
   def standard?
@@ -27,22 +27,24 @@ class NanoElement < ApplicationRecord
     purposes.present? && purposes.include?("other")
   end
 
-  def notified_toxicology?
+  protected
+
+  def toxicology_incomplete?
     confirm_toxicology_notified.nil? ||
-      confirm_toxicology_notified == "not_sure" ||
+      confirm_toxicology_notified == "not sure" ||
       confirm_toxicology_notified == "no"
   end
 
-  def restrictions_confirmed?
+  def restrictions_confirmed_incomplete?
     confirm_restrictions.nil? ||
-      (confirm_restrictions == "no" && notified_toxicology?) ||
+      (confirm_restrictions == "no" && toxicology_incomplete?) ||
       (
-        confirm_restrictions == "yes" && usage_confirmed? ||
-       (confirm_usage == "no" && notified_toxicology?)
+        confirm_restrictions == "yes" && usage_confirmed_incomplete? ||
+       (confirm_usage == "no" && toxicology_incomplete?)
       )
   end
 
-  def usage_confirmed?
+  def usage_confirmed_incomplete?
     confirm_usage.nil?
   end
 end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -27,7 +27,7 @@ class NanoElement < ApplicationRecord
     purposes.present? && purposes.include?("other")
   end
 
-  protected
+protected
 
   def toxicology_incomplete?
     confirm_toxicology_notified.nil? ||

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -19,8 +19,11 @@ class NanoElement < ApplicationRecord
       (
         standard? && (
           confirm_restrictions.nil? ||
-          (confirm_restrictions == "no" && confirm_toxicology_notified.nil?) ||
-          (confirm_restrictions == "yes" && confirm_usage.nil?)
+          (
+            confirm_restrictions == 'no' && confirm_toxicology_notified.nil? ||
+            (confirm_toxicology_notified == 'not_sure' || confirm_toxicology_notified == 'no')
+          ) ||
+         (confirm_restrictions == 'yes' && confirm_usage.nil?)
         )
       )
   end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -36,6 +36,10 @@ class NanoElement < ApplicationRecord
   def restrictions_confirmed?
     confirm_restrictions.nil? ||
       (confirm_restrictions == "no" && notified_toxicology?) ||
-      (confirm_restrictions == "yes" && confirm_usage.nil?)
+      (confirm_restrictions == "yes" && usage_confirmed?)
+  end
+
+  def usage_confirmed?
+    (confirm_usage.nil? || confirm_usage == "no")
   end
 end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -39,7 +39,7 @@ private
     confirm_restrictions.nil? ||
       (confirm_restrictions == "no" && toxicology_incomplete?) ||
       (
-        confirm_restrictions == "yes" && usage_confirmed_incomplete? ||
+        (confirm_restrictions == "yes" && usage_confirmed_incomplete?) ||
        (confirm_usage == "no" && toxicology_incomplete?)
       )
   end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -36,7 +36,10 @@ class NanoElement < ApplicationRecord
   def restrictions_confirmed?
     confirm_restrictions.nil? ||
       (confirm_restrictions == "no" && notified_toxicology?) ||
-      (confirm_restrictions == "yes" && usage_confirmed?)
+      (
+        confirm_restrictions == "yes" && usage_confirmed? ||
+       (confirm_usage == "no" && notified_toxicology?)
+      )
   end
 
   def usage_confirmed?

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -27,7 +27,7 @@ class NanoElement < ApplicationRecord
     purposes.present? && purposes.include?("other")
   end
 
-protected
+private
 
   def toxicology_incomplete?
     confirm_toxicology_notified.nil? ||

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -15,17 +15,8 @@ class NanoElement < ApplicationRecord
 
   def incomplete?
     purposes.blank? ||
-      (non_standard? && confirm_toxicology_notified.nil?) ||
-      (
-        standard? && (
-          confirm_restrictions.nil? ||
-          (
-            confirm_restrictions == 'no' && confirm_toxicology_notified.nil? ||
-            (confirm_toxicology_notified == 'not_sure' || confirm_toxicology_notified == 'no')
-          ) ||
-         (confirm_restrictions == 'yes' && confirm_usage.nil?)
-        )
-      )
+      (non_standard? && notified_toxicology?) ||
+      (standard? && restrictions_confirmed?)
   end
 
   def standard?
@@ -34,5 +25,17 @@ class NanoElement < ApplicationRecord
 
   def non_standard?
     purposes.present? && purposes.include?("other")
+  end
+
+  def notified_toxicology?
+    confirm_toxicology_notified.nil? ||
+      confirm_toxicology_notified == 'not_sure' ||
+      confirm_toxicology_notified == 'no'
+  end
+
+  def restrictions_confirmed?
+    confirm_restrictions.nil? ||
+      (confirm_restrictions == 'no' && notified_toxicology?) ||
+      (confirm_restrictions == 'yes' && confirm_usage.nil?)
   end
 end

--- a/cosmetics-web/app/models/nano_element.rb
+++ b/cosmetics-web/app/models/nano_element.rb
@@ -29,13 +29,13 @@ class NanoElement < ApplicationRecord
 
   def notified_toxicology?
     confirm_toxicology_notified.nil? ||
-      confirm_toxicology_notified == 'not_sure' ||
-      confirm_toxicology_notified == 'no'
+      confirm_toxicology_notified == "not_sure" ||
+      confirm_toxicology_notified == "no"
   end
 
   def restrictions_confirmed?
     confirm_restrictions.nil? ||
-      (confirm_restrictions == 'no' && notified_toxicology?) ||
-      (confirm_restrictions == 'yes' && confirm_usage.nil?)
+      (confirm_restrictions == "no" && notified_toxicology?) ||
+      (confirm_restrictions == "yes" && confirm_usage.nil?)
   end
 end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -258,18 +258,6 @@ RSpec.describe NanoElement, type: :model do
 
           expect(nano_element).to be_incomplete
         end
-
-        it "has confirmed usage as 'no'" do
-          nano_element.confirm_usage = "no"
-
-          expect(nano_element).not_to be_incomplete
-        end
-
-        it "has confirmed usage as 'yes'" do
-          nano_element.confirm_usage = "yes"
-
-          expect(nano_element).not_to be_incomplete
-        end
       end
     end
 
@@ -297,6 +285,12 @@ RSpec.describe NanoElement, type: :model do
 
         it "has confirmed usage as 'yes'" do
           nano_element.confirm_usage = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+
+        it "has confirmed usage as 'no'" do
+          nano_element.confirm_usage = "no"
 
           expect(nano_element).not_to be_incomplete
         end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe NanoElement, type: :model do
         it "has confirmed usage as 'no'" do
           nano_element.confirm_usage = "no"
 
-          expect(nano_element).to be_incomplete
+          expect(nano_element).not_to be_incomplete
         end
 
         it "has confirmed usage as 'yes'" do
@@ -262,7 +262,7 @@ RSpec.describe NanoElement, type: :model do
         it "has confirmed usage as 'no'" do
           nano_element.confirm_usage = "no"
 
-          expect(nano_element).to be_incomplete
+          expect(nano_element).not_to be_incomplete
         end
 
         it "has confirmed usage as 'yes'" do

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -130,6 +130,22 @@ RSpec.describe NanoElement, type: :model do
           expect(nano_element).to be_incomplete
         end
       end
+
+      context "when toxicology has not been notified" do
+        it "confirms toxicology has not been notified" do
+          nano_element.confirm_restrictions = "no"
+          nano_element.confirm_toxicology_notified = "no"
+
+          expect(nano_element).to be_incomplete
+        end
+
+        it "is not sure toxicology has been notified" do
+          nano_element.confirm_restrictions = "no"
+          nano_element.confirm_toxicology_notified = "not_sure"
+
+          expect(nano_element).to be_incomplete
+        end
+      end
     end
   end
 end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe NanoElement, type: :model do
         end
 
         it "is set to 'not sure'" do
-          nano_element.confirm_toxicology_notified = "not_sure"
+          nano_element.confirm_toxicology_notified = "not sure"
 
           expect(nano_element).to be_incomplete
         end
@@ -152,7 +152,7 @@ RSpec.describe NanoElement, type: :model do
         end
 
         it "is not sure toxicology has been notified" do
-          nano_element.confirm_toxicology_notified = "not_sure"
+          nano_element.confirm_toxicology_notified = "not sure"
 
           expect(nano_element).to be_incomplete
         end
@@ -236,7 +236,7 @@ RSpec.describe NanoElement, type: :model do
         end
 
         it "is not sure toxicology has been notified" do
-          nano_element.confirm_toxicology_notified = "not_sure"
+          nano_element.confirm_toxicology_notified = "not sure"
 
           expect(nano_element).to be_incomplete
         end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe NanoElement, type: :model do
         it "has confirmed usage as 'no'" do
           nano_element.confirm_usage = "no"
 
-          expect(nano_element).not_to be_incomplete
+          expect(nano_element).to be_incomplete
         end
 
         it "has confirmed usage as 'yes'" do
@@ -290,6 +290,7 @@ RSpec.describe NanoElement, type: :model do
         end
 
         it "has confirmed usage as 'no'" do
+          nano_element.confirm_toxicology_notified = "yes"
           nano_element.confirm_usage = "no"
 
           expect(nano_element).not_to be_incomplete

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -88,6 +88,26 @@ RSpec.describe NanoElement, type: :model do
 
         expect(nano_element).to be_incomplete
       end
+
+      context "when toxicology has not been notified" do
+        before do
+          nano_element.purposes = %w(other)
+        end
+
+        it "confirms toxicology has not been notified" do
+          nano_element.confirm_restrictions = "no"
+          nano_element.confirm_toxicology_notified = "no"
+
+          expect(nano_element).to be_incomplete
+        end
+
+        it "is not sure toxicology has been notified" do
+          nano_element.confirm_restrictions = "no"
+          nano_element.confirm_toxicology_notified = "not_sure"
+
+          expect(nano_element).to be_incomplete
+        end
+      end
     end
 
     context "when a standard nanomaterial notification is incomplete" do

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -166,6 +166,19 @@ RSpec.describe NanoElement, type: :model do
           expect(nano_element).to be_incomplete
         end
       end
+
+      context "when nano element has restrictions and usage is set to 'no'" do
+        before do
+          nano_element.purposes = %w(colorant)
+
+          nano_element.confirm_restrictions = "yes"
+          nano_element.confirm_usage = "no"
+        end
+
+        it "returns incomplete" do
+          expect(nano_element).to be_incomplete
+        end
+      end
     end
   end
 end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -92,20 +92,33 @@ RSpec.describe NanoElement, type: :model do
       context "when toxicology notified is set" do
         before do
           nano_element.purposes = %w(other)
+          nano_element.confirm_restrictions = "no"
         end
 
         it "is set to 'no'" do
-          nano_element.confirm_restrictions = "no"
           nano_element.confirm_toxicology_notified = "no"
 
           expect(nano_element).to be_incomplete
         end
 
         it "is set to 'not sure'" do
-          nano_element.confirm_restrictions = "no"
           nano_element.confirm_toxicology_notified = "not_sure"
 
           expect(nano_element).to be_incomplete
+        end
+      end
+    end
+
+    context "when a nonstandard nanomaterial notification is complete" do
+      before do
+        nano_element.purposes = %w(other)
+      end
+
+      context "when toxicology has been notified" do
+        it "has confirmed as 'yes'" do
+          nano_element.confirm_toxicology_notified = "yes"
+
+          expect(nano_element).not_to be_incomplete
         end
       end
     end
@@ -132,10 +145,16 @@ RSpec.describe NanoElement, type: :model do
           expect(nano_element).to be_incomplete
         end
 
-        it "is not incomplete when toxicology is notified" do
-          nano_element.confirm_toxicology_notified = "yes"
+        it "confirms toxicology has not been notified" do
+          nano_element.confirm_toxicology_notified = "no"
 
-          expect(nano_element).not_to be_incomplete
+          expect(nano_element).to be_incomplete
+        end
+
+        it "is not sure toxicology has been notified" do
+          nano_element.confirm_toxicology_notified = "not_sure"
+
+          expect(nano_element).to be_incomplete
         end
       end
 
@@ -149,34 +168,137 @@ RSpec.describe NanoElement, type: :model do
 
           expect(nano_element).to be_incomplete
         end
+
+        it "has confirmed usage as 'no'" do
+          nano_element.confirm_usage = "no"
+
+          expect(nano_element).to be_incomplete
+        end
+
+        it "has confirmed usage as 'yes'" do
+          nano_element.confirm_usage = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+      end
+    end
+
+    context "when a standard nanomaterial is complete" do
+      before do
+        nano_element.purposes = %w(colorant)
       end
 
-      context "when toxicology has not been notified" do
-        it "confirms toxicology has not been notified" do
+      context "when restrictions are set to 'no'" do
+        before do
           nano_element.confirm_restrictions = "no"
+        end
+
+        it "is not incomplete when toxicology is notified" do
+          nano_element.confirm_toxicology_notified = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+      end
+
+      context "when restrictions are set to 'yes'" do
+        before do
+          nano_element.confirm_restrictions = "yes"
+        end
+
+        it "has confirmed usage as 'yes'" do
+          nano_element.confirm_usage = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+      end
+    end
+
+    context "when a standard nanomaterial notification is incomplete" do
+      before do
+        nano_element.purposes = %w(colorant)
+      end
+
+      it "has not confirmed restrictions" do
+        nano_element.confirm_restrictions = nil
+
+        expect(nano_element).to be_incomplete
+      end
+
+      context "when restrictions are set to 'no'" do
+        before do
+          nano_element.confirm_restrictions = "no"
+        end
+
+        it "must have set confirm toxicology has been notified" do
+          nano_element.confirm_toxicology_notified = nil
+
+          expect(nano_element).to be_incomplete
+        end
+
+        it "confirms toxicology has not been notified" do
           nano_element.confirm_toxicology_notified = "no"
 
           expect(nano_element).to be_incomplete
         end
 
         it "is not sure toxicology has been notified" do
-          nano_element.confirm_restrictions = "no"
           nano_element.confirm_toxicology_notified = "not_sure"
 
           expect(nano_element).to be_incomplete
         end
       end
 
-      context "when nano element has restrictions and usage is set to 'no'" do
+      context "when restrictions are set to 'yes'" do
         before do
-          nano_element.purposes = %w(colorant)
-
           nano_element.confirm_restrictions = "yes"
-          nano_element.confirm_usage = "no"
         end
 
-        it "returns incomplete" do
+        it "has not confirmed usage" do
+          nano_element.confirm_usage = nil
+
           expect(nano_element).to be_incomplete
+        end
+
+        it "has confirmed usage as 'no'" do
+          nano_element.confirm_usage = "no"
+
+          expect(nano_element).to be_incomplete
+        end
+
+        it "has confirmed usage as 'yes'" do
+          nano_element.confirm_usage = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+      end
+    end
+
+    context "when a standard nanomaterial is complete" do
+      before do
+        nano_element.purposes = %w(colorant)
+      end
+
+      context "when restrictions are set to 'no'" do
+        before do
+          nano_element.confirm_restrictions = "no"
+        end
+
+        it "is not incomplete when toxicology is notified" do
+          nano_element.confirm_toxicology_notified = "yes"
+
+          expect(nano_element).not_to be_incomplete
+        end
+      end
+
+      context "when restrictions are set to 'yes'" do
+        before do
+          nano_element.confirm_restrictions = "yes"
+        end
+
+        it "has confirmed usage as 'yes'" do
+          nano_element.confirm_usage = "yes"
+
+          expect(nano_element).not_to be_incomplete
         end
       end
     end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -82,26 +82,26 @@ RSpec.describe NanoElement, type: :model do
         expect(nano_element).to be_incomplete
       end
 
-      it "has not confirmed that toxicology notified" do
+      it "toxicology notified is not set" do
         nano_element.purposes = %w(other)
         nano_element.confirm_toxicology_notified = nil
 
         expect(nano_element).to be_incomplete
       end
 
-      context "when toxicology has not been notified" do
+      context "when toxicology notified is set" do
         before do
           nano_element.purposes = %w(other)
         end
 
-        it "confirms toxicology has not been notified" do
+        it "is set to 'no'" do
           nano_element.confirm_restrictions = "no"
           nano_element.confirm_toxicology_notified = "no"
 
           expect(nano_element).to be_incomplete
         end
 
-        it "is not sure toxicology has been notified" do
+        it "is set to 'not sure'" do
           nano_element.confirm_restrictions = "no"
           nano_element.confirm_toxicology_notified = "not_sure"
 
@@ -121,7 +121,7 @@ RSpec.describe NanoElement, type: :model do
         expect(nano_element).to be_incomplete
       end
 
-      context "when restrictions is set to 'no'" do
+      context "when restrictions are set to 'no'" do
         before do
           nano_element.confirm_restrictions = "no"
         end
@@ -139,7 +139,7 @@ RSpec.describe NanoElement, type: :model do
         end
       end
 
-      context "when restrictions is set to 'yes'" do
+      context "when restrictions are set to 'yes'" do
         before do
           nano_element.confirm_restrictions = "yes"
         end

--- a/cosmetics-web/spec/models/nano_element_spec.rb
+++ b/cosmetics-web/spec/models/nano_element_spec.rb
@@ -174,12 +174,6 @@ RSpec.describe NanoElement, type: :model do
 
           expect(nano_element).to be_incomplete
         end
-
-        it "has confirmed usage as 'yes'" do
-          nano_element.confirm_usage = "yes"
-
-          expect(nano_element).not_to be_incomplete
-        end
       end
     end
 


### PR DESCRIPTION
## Description
This PR addresses making sure that nano-matieral, which are not notified within the UK, are classed as "incomplete".

This means that the only way that a user can complete a notification is when they have confirmed that toxicology has been notified within the UK, for all nano-material present.

As the main change here is to update the definition of "incomplete", for a nano-material, we enhance the 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.