### PR TITLE
Bugfix: remove pH range if answer changed to not require it

### DIFF
--- a/cosmetics-web/app/models/component.rb
+++ b/cosmetics-web/app/models/component.rb
@@ -138,6 +138,16 @@ class Component < ApplicationRecord
     super(reject_non_decimal_strings(value))
   end
 
+  def ph=(value)
+    super(value)
+
+    # Remove min and max pH if no longer required
+    if ph_range_not_required?
+      self.minimum_ph = nil
+      self.maximum_ph = nil
+    end
+  end
+
   def ph_range_not_required?
     ph_between_3_and_10? || ph_not_applicable?
   end

--- a/cosmetics-web/spec/models/component_spec.rb
+++ b/cosmetics-web/spec/models/component_spec.rb
@@ -352,5 +352,25 @@ RSpec.describe Component, type: :model do
       expect(predefined_component).not_to be_valid(:ph_range)
       expect(predefined_component.errors[:maximum_ph]).to include("The maximum pH cannot be more than 1 higher than the minimum pH")
     end
+
+    context "when changing the pH answer after giving an explicit range" do
+      before do
+        # Explicit pH range given
+        predefined_component.ph = "lower_than_3"
+        predefined_component.minimum_ph = 2.0
+        predefined_component.maximum_ph = 3.0
+
+        # Answer changed to 'no pH'
+        predefined_component.ph = "not_applicable"
+      end
+
+      it "removes the previous minimum pH" do
+        expect(predefined_component.minimum_ph).to be_nil
+      end
+
+      it "removes the previous maximum pH" do
+        expect(predefined_component.maximum_ph).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes the following bug:

If you select "The minimum pH is lower than 3" for a component, and then give an explicit range (eg 2.3 to 3.0), but then go back and change the answer to the first question to be "It does not have a pH", the 2.3–3.0 pH range was not removed from the component.

This wasn't really visible unless you changed your answer _again_ to require a pH range, in which case your previous answer was still there.

Spotted by @nasirkhanbeis as part of #1471. 👍 