### PR TITLE
Make sure users can only submit a notification when there is no more information to add.

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -99,7 +99,7 @@ class Notification < ApplicationRecord
       transitions from: :draft_complete, to: :notification_complete,
                   after: Proc.new { __elasticsearch__.index_document } do
         guard do
-          notified_pre_eu_exit? || images_are_present_and_safe?
+          (notified_pre_eu_exit? || images_are_present_and_safe?) && !missing_information?
         end
       end
     end

--- a/cosmetics-web/spec/factories/image_upload.rb
+++ b/cosmetics-web/spec/factories/image_upload.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :image_upload do
+    file { Rack::Test::UploadedFile.new("spec/fixtures/testPdf.pdf", "image/png") }
+
     trait :uploaded_and_virus_scanned do
       after :create do |image_upload|
-        file = fixture_file_upload(Rails.root.join("spec", "fixtures", "testImage.png"), "image/png")
-        image_upload.file.attach(file)
         image_upload.file.metadata["safe"] = "true"
       end
     end

--- a/cosmetics-web/spec/factories/image_upload.rb
+++ b/cosmetics-web/spec/factories/image_upload.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :image_upload do
+    trait :uploaded_and_virus_scanned do
+      after :create do |image_upload|
+        file = fixture_file_upload(Rails.root.join("spec", "fixtures", "testImage.png"), "image/png")
+        image_upload.file.attach(file)
+        image_upload.file.metadata["safe"] = "true"
+      end
+    end
+  end
+end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Notification, type: :model do
 
       context "when notified pre EU exit" do
         before do
-          allow(notification).to receive(:notified_pre_eu_exit?).and_return(true)
+          notification.was_notified_before_eu_exit = true
         end
 
         it "can submit a notification" do
@@ -100,8 +100,14 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when images are present and safe" do
+        let(:image_upload) { ImageUpload.new }
+        let(:file) { fixture_file_upload("/testImage.png", "image/png") }
+
         before do
-          allow(notification).to receive(:images_are_present_and_safe?).and_return(true)
+          image_upload.file.attach(file)
+          image_upload.file.metadata["safe"] = "true"
+
+          notification.image_uploads = [image_upload]
         end
 
         it "can submit a notification" do
@@ -117,7 +123,7 @@ RSpec.describe Notification, type: :model do
 
       context "when notified pre EU exit" do
         before do
-          allow(notification).to receive(:notified_pre_eu_exit?).and_return(true)
+          notification.was_notified_before_eu_exit = true
         end
 
         it "can not submit a notification" do
@@ -125,9 +131,15 @@ RSpec.describe Notification, type: :model do
         end
       end
 
-      context "when images are present and safe" do
+      context "when images is present and safe" do
+        let(:image_upload) { ImageUpload.new }
+        let(:file) { fixture_file_upload("/testImage.png", "image/png") }
+
         before do
-          allow(notification).to receive(:images_are_present_and_safe?).and_return(true)
+          image_upload.file.attach(file)
+          image_upload.file.metadata["safe"] = "true"
+
+          notification.image_uploads = [image_upload]
         end
 
         it "can not submit a notification" do

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -82,17 +82,9 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#may_submit_notification?" do
-    let(:notification) { create(:draft_notification) }
-
     context "when no missing information" do
-      before do
-        allow(notification).to receive(:missing_information?).and_return(false)
-      end
-
       context "when notified pre EU exit" do
-        before do
-          notification.was_notified_before_eu_exit = true
-        end
+        let(:notification) { create(:draft_notification, :pre_brexit) }
 
         it "can submit a notification" do
           expect(notification).to be_may_submit_notification
@@ -100,15 +92,8 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when images are present and safe" do
-        let(:image_upload) { ImageUpload.new }
-        let(:file) { fixture_file_upload("/testImage.png", "image/png") }
-
-        before do
-          image_upload.file.attach(file)
-          image_upload.file.metadata["safe"] = "true"
-
-          notification.image_uploads = [image_upload]
-        end
+        let(:notification) { create(:draft_notification, image_uploads: [image_upload]) }
+        let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
 
         it "can submit a notification" do
           expect(notification).to be_may_submit_notification
@@ -122,9 +107,7 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when notified pre EU exit" do
-        before do
-          notification.was_notified_before_eu_exit = true
-        end
+        let(:notification) { create(:draft_notification, :pre_brexit) }
 
         it "can not submit a notification" do
           expect(notification).not_to be_may_submit_notification
@@ -132,15 +115,8 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when images is present and safe" do
-        let(:image_upload) { ImageUpload.new }
-        let(:file) { fixture_file_upload("/testImage.png", "image/png") }
-
-        before do
-          image_upload.file.attach(file)
-          image_upload.file.metadata["safe"] = "true"
-
-          notification.image_uploads = [image_upload]
-        end
+        let(:notification) { create(:draft_notification, image_uploads: [image_upload]) }
+        let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
 
         it "can not submit a notification" do
           expect(notification).not_to be_may_submit_notification

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -82,9 +82,13 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#may_submit_notification?" do
+    let(:nano_element) { create(:nano_element, confirm_toxicology_notified: "yes", purposes: %w(other)) }
+    let(:nano_material) { create(:nano_material, nano_elements: [nano_element]) }
+    let(:component) { create(:component, nano_material: nano_material) }
+
     context "when no missing information" do
       context "when notified pre EU exit" do
-        let(:notification) { create(:draft_notification, :pre_brexit) }
+        let(:notification) { create(:draft_notification, :pre_brexit, components: [component]) }
 
         it "can submit a notification" do
           expect(notification).to be_may_submit_notification
@@ -92,7 +96,7 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when images are present and safe" do
-        let(:notification) { create(:draft_notification, image_uploads: [image_upload]) }
+        let(:notification) { create(:draft_notification, image_uploads: [image_upload], components: [component]) }
         let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
 
         it "can submit a notification" do
@@ -102,12 +106,12 @@ RSpec.describe Notification, type: :model do
     end
 
     context "when information is missing" do
-      before do
-        allow(notification).to receive(:missing_information?).and_return(true)
-      end
+      let(:nano_element) { create(:nano_element, confirm_toxicology_notified: "no", purposes: %w(other)) }
+      let(:nano_material) { create(:nano_material, nano_elements: [nano_element]) }
+      let(:component) { create(:component, nano_material: nano_material) }
 
       context "when notified pre EU exit" do
-        let(:notification) { create(:draft_notification, :pre_brexit) }
+        let(:notification) { create(:draft_notification, :pre_brexit, components: [component]) }
 
         it "can not submit a notification" do
           expect(notification).not_to be_may_submit_notification
@@ -115,7 +119,7 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when images is present and safe" do
-        let(:notification) { create(:draft_notification, image_uploads: [image_upload]) }
+        let(:notification) { create(:draft_notification, image_uploads: [image_upload], components: [component]) }
         let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
 
         it "can not submit a notification" do

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -80,4 +80,60 @@ RSpec.describe Notification, type: :model do
       end
     end
   end
+
+  describe "#may_submit_notification?" do
+    let(:notification) { create(:draft_notification) }
+
+    context "when no missing information" do
+      before do
+        allow(notification).to receive(:missing_information?).and_return(false)
+      end
+
+      context "when notified pre EU exit" do
+        before do
+          allow(notification).to receive(:notified_pre_eu_exit?).and_return(true)
+        end
+
+        it "can submit a notification" do
+          expect(notification).to be_may_submit_notification
+        end
+      end
+
+      context "when images are present and safe" do
+        before do
+          allow(notification).to receive(:images_are_present_and_safe?).and_return(true)
+        end
+
+        it "can submit a notification" do
+          expect(notification).to be_may_submit_notification
+        end
+      end
+    end
+
+    context "when information is missing" do
+      before do
+        allow(notification).to receive(:missing_information?).and_return(true)
+      end
+
+      context "when notified pre EU exit" do
+        before do
+          allow(notification).to receive(:notified_pre_eu_exit?).and_return(true)
+        end
+
+        it "can not submit a notification" do
+          expect(notification).not_to be_may_submit_notification
+        end
+      end
+
+      context "when images are present and safe" do
+        before do
+          allow(notification).to receive(:images_are_present_and_safe?).and_return(true)
+        end
+
+        it "can not submit a notification" do
+          expect(notification).not_to be_may_submit_notification
+        end
+      end
+    end
+  end
 end

--- a/cosmetics-web/spec/rails_helper.rb
+++ b/cosmetics-web/spec/rails_helper.rb
@@ -69,8 +69,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.include FactoryBot::Syntax::Methods
+  FactoryBot::SyntaxRunner.class_eval do
+    include ActionDispatch::TestProcess
+  end
 
+  config.include FactoryBot::Syntax::Methods
   config.include DomainHelpers
   config.include LoginHelpers
   config.include ResponsiblePersonHelpers

--- a/cosmetics-web/spec/rails_helper.rb
+++ b/cosmetics-web/spec/rails_helper.rb
@@ -69,10 +69,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  FactoryBot::SyntaxRunner.class_eval do
-    include ActionDispatch::TestProcess
-  end
-
   config.include FactoryBot::Syntax::Methods
   config.include DomainHelpers
   config.include LoginHelpers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Resolves issue where users were allowed to notify a product whilst there was still missing information.

Review app: https://cosmetics-pr-1485-submit-web.london.cloudapps.digital/
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.