### PR TITLE
Eliminate e-mail address collisions in automated tests

### DIFF
--- a/cosmetics-web/spec/system/user_registration_spec.rb
+++ b/cosmetics-web/spec/system/user_registration_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Account registration", type: :system do
     create_new_account
 
     fill_in "Full name", with: "New User"
-    fill_in "Work email address", with: "test#{rand(100)}@example.com"
+    fill_in "Work email address", with: "test#{Time.now.to_f}@example.com"
     fill_in "Mobile phone number", with: "07797 900982"
     fill_in "Password", with: "complex_password"
     fill_in "Confirm password", with: "complex_password"


### PR DESCRIPTION
Currently we’re using a shared Keycloak instance for our automated tests, with no regular purging of the database, so it is filling up with test user accounts. This is resulting in random test failures when the e-mail address is already taken.

By changing from a 1 to 100 random number to a number based on the current time (in milliseconds) we should eliminate the chance of a e-mail address collision.