### PR TITLE
Refactor how we check for images before we submit a notification

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -99,7 +99,7 @@ class Notification < ApplicationRecord
       transitions from: :draft_complete, to: :notification_complete,
                   after: Proc.new { __elasticsearch__.index_document } do
         guard do
-          (notified_pre_eu_exit? || images_are_present_and_safe?) && !missing_information?
+          !missing_information?
         end
       end
     end
@@ -157,7 +157,8 @@ class Notification < ApplicationRecord
   end
 
   def images_required?
-    notified_post_eu_exit? && image_uploads.empty?
+    (notified_pre_eu_exit? && !images_are_present_and_safe?) ||
+      (notified_post_eu_exit? && image_uploads.empty?)
   end
 
   def get_valid_multicomponents

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -40,13 +40,9 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#images_required?" do
-    let(:notification) { build(:notification) }
-
     context "when the notification has no images uploaded" do
       context "when notifiying pre EU exit" do
-        before do
-          notification.was_notified_before_eu_exit = true
-        end
+        let(:notification) { build(:draft_notification, :pre_brexit) }
 
         it "requires an image upload" do
           expect(notification).to be_images_required
@@ -54,9 +50,7 @@ RSpec.describe Notification, type: :model do
       end
 
       context "when notifiying post EU exit" do
-        before do
-          notification.was_notified_before_eu_exit = false
-        end
+        let(:notification) { build(:draft_notification, :post_brexit) }
 
         it "does not require an image upload" do
           expect(notification).to be_images_required

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -108,49 +108,24 @@ RSpec.describe Notification, type: :model do
   end
 
   describe "#may_submit_notification?" do
-    let(:nano_element) { create(:nano_element, confirm_toxicology_notified: "yes", purposes: %w(other)) }
-    let(:nano_material) { create(:nano_material, nano_elements: [nano_element]) }
-    let(:component) { create(:component, nano_material: nano_material) }
+    let(:nano_element) { build(:nano_element, confirm_toxicology_notified: "yes", purposes: %w(other)) }
+    let(:nano_material) { build(:nano_material, nano_elements: [nano_element]) }
+    let(:component) { build(:component, nano_material: nano_material) }
 
-    context "when no missing information" do
-      context "when notified pre EU exit" do
-        let(:notification) { create(:draft_notification, :pre_brexit, components: [component]) }
+    context "when no information is missing" do
+      let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
+      let(:notification) { build(:draft_notification, :pre_brexit, image_uploads: [image_upload], components: [component]) }
 
-        it "can submit a notification" do
-          expect(notification).to be_may_submit_notification
-        end
-      end
-
-      context "when images are present and safe" do
-        let(:notification) { create(:draft_notification, image_uploads: [image_upload], components: [component]) }
-        let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
-
-        it "can submit a notification" do
-          expect(notification).to be_may_submit_notification
-        end
+      it "can submit a notification" do
+        expect(notification).to be_may_submit_notification
       end
     end
 
     context "when information is missing" do
-      let(:nano_element) { create(:nano_element, confirm_toxicology_notified: "no", purposes: %w(other)) }
-      let(:nano_material) { create(:nano_material, nano_elements: [nano_element]) }
-      let(:component) { create(:component, nano_material: nano_material) }
+      let(:notification) { build(:draft_notification, :pre_brexit, components: [component]) }
 
-      context "when notified pre EU exit" do
-        let(:notification) { create(:draft_notification, :pre_brexit, components: [component]) }
-
-        it "can not submit a notification" do
-          expect(notification).not_to be_may_submit_notification
-        end
-      end
-
-      context "when images is present and safe" do
-        let(:notification) { create(:draft_notification, image_uploads: [image_upload], components: [component]) }
-        let(:image_upload) { create(:image_upload, :uploaded_and_virus_scanned) }
-
-        it "can not submit a notification" do
-          expect(notification).not_to be_may_submit_notification
-        end
+      it "can not submit a notification" do
+        expect(notification).not_to be_may_submit_notification
       end
     end
   end

--- a/cosmetics-web/spec/models/notification_spec.rb
+++ b/cosmetics-web/spec/models/notification_spec.rb
@@ -39,6 +39,32 @@ RSpec.describe Notification, type: :model do
     end
   end
 
+  describe "#images_required?" do
+    let(:notification) { build(:notification) }
+
+    context "when the notification has no images uploaded" do
+      context "when notifiying pre EU exit" do
+        before do
+          notification.was_notified_before_eu_exit = true
+        end
+
+        it "requires an image upload" do
+          expect(notification).to be_images_required
+        end
+      end
+
+      context "when notifiying post EU exit" do
+        before do
+          notification.was_notified_before_eu_exit = false
+        end
+
+        it "does not require an image upload" do
+          expect(notification).to be_images_required
+        end
+      end
+    end
+  end
+
   describe "#missing_information?" do
     let(:notification) { build(:notification) }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
When we check whether a notification has missing information didn't address pre EU exit images checks.

This PR adds a check to the image check requirements, to make sure that a pre EU exit notification doesn't have any images uploaded. Addressing a point made [here](https://github.com/UKGovernmentBEIS/beis-opss/pull/1485/files#r353805729)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
