### PR TITLE
Refactor ReadDataAnalyzer

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/notification_files_controller.rb
@@ -36,6 +36,8 @@ class ResponsiblePersons::NotificationFilesController < ApplicationController
         })
         return render :new
       end
+
+      NotificationFileProcessorJob.perform_later(notification_file.id)
     end
     redirect_to responsible_person_notifications_path(@responsible_person)
   end

--- a/cosmetics-web/app/jobs/notification_file_processor_job.rb
+++ b/cosmetics-web/app/jobs/notification_file_processor_job.rb
@@ -9,7 +9,7 @@ class NotificationFileProcessorJob < ApplicationJob
     @notification_file = NotificationFile.find(notification_file_id)
     create_notification_from_file
     delete_notification_file if @notification_file.upload_error.blank?
-    return true
+    true
   end
 
   def blob
@@ -86,10 +86,8 @@ private
   end
 
   def get_product_xml_file
-
     download_blob_to_tempfile do |zip_file|
       Zip::File.open(zip_file.path) do |files|
-
         valid_files = files.select { |file| file_is_valid?(file) }
         if invalid_static_files(valid_files)
           raise UnexpectedStaticFilesError, "UnexpectedStaticFilesError - a different static file was detected!"

--- a/cosmetics-web/config/initializers/storage.rb
+++ b/cosmetics-web/config/initializers/storage.rb
@@ -7,7 +7,7 @@ if ENV.fetch("ANTIVIRUS_ENABLED", "true") == "true"
   Rails.application.config.document_analyzers.append AntiVirusAnalyzer
 end
 
-Rails.application.config.document_analyzers.append ReadDataAnalyzer
+# Rails.application.config.document_analyzers.append ReadDataAnalyzer
 # MasterAnalyzer is the only one that we pass to active_storage
 Rails.application.config.active_storage.analyzers = [MasterAnalyzer]
 Rails.application.config.active_storage.queue = :cosmetics

--- a/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
+++ b/cosmetics-web/spec/jobs/notification_file_processor_job_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe NotificationFileProcessorJob do
   end
 
   describe "#perform" do
-
     it "creates a notification and removes a notification file" do
       expect {
         described_class.new.perform(notification_file_basic.id)
@@ -122,7 +121,6 @@ RSpec.describe NotificationFileProcessorJob do
     end
 
     it "creates a notification populated with relevant number of cmr" do
-
       expect {
         described_class.new.perform(notification_file_nano_materials_cmr.id)
       }.to change(Cmr, :count).by(2)
@@ -206,7 +204,7 @@ RSpec.describe NotificationFileProcessorJob do
       before do
         notification_file = create(:notification_file, uploaded_file: create_file_blob("testExportWithComponentWithSinglePHValue.zip"))
 
-        analyzer_instance = described_class.new.perform(notification_file.id)
+        described_class.new.perform(notification_file.id)
       end
 
       let(:notification) { Notification.order(created_at: :asc).last }


### PR DESCRIPTION
This refactors the class which parses the XML files (within ZIP files) attached to `NotificationFile` models, and create `Notification` models instead.

The main motivation behind this is the discovery that within the existing `ReadDataAnalyzer` specs, the `ReadDataAnalyzer` class is being called automatically during the setup of the uploaded files, rather than (or sometimes as well as) explicitly within the `analyzer_instance.metadata` call. Whilst this had little effect when running the the jobs using the `:async` method (a separate thread), changing this to `:inline` caused all the tests to fail.

Whilst the XML parsing & importing can be thought of as a type of "analyzer", it doesn't feel like a good fit for `ActiveStorage::Analyzer`, as that is designed purely for adding metadata to existing files, rather than fundamentally processing them into records and then deleting the file.

## Before

`ReadDataAnalyzer` is a subclass of `ActiveStorage::Analyzer` and is run within `ActiveStorage::AnalyzeJob` immediately after every file is uploaded. Following the ActiveStorae::Analyzer` API, the `accept?` class method is first called to see whether or not to apply the analyzer, and if so, the `metadata` instance method is called.

The `metadata` method returns an empty hash, because that is what the ActiveStorage job is expecting to add to the metadata column in the database - but instead were using this method to analyze the xml file, create a notification record, and then delete the notification_file itself.

## After

There is a new `NotificationFileProcessorJob` which is queued (or run inline) with the `id` of the `NotificationFile`. Following the ActiveJob API, when the `perform` method is called, all of the same code is run as before – the attached file is downloaded, unzipped, and then a `Notification` record is saved, and the `NotificationFile` record is deleted.

When uploading the zip files, the `NotificationFilesController` now explicitly queues the job to process the files, via `NotificationFileProcessorJob.perform_later(notification_file.id)`
