### PR TITLE
Specify sort order when looping through components and nano elements

### DIFF
--- a/cosmetics-web/app/controllers/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/additional_information_controller.rb
@@ -3,11 +3,11 @@ class AdditionalInformationController < ApplicationController
 
   def index
     if @notification.nano_material_required?
-      component = @notification.components.find(&:nano_material_required?)
-      nano_element = component.nano_material.nano_elements.find(&:required?)
+      component = @notification.components.order(:id).find(&:nano_material_required?)
+      nano_element = component.nano_material.nano_elements.order(:id).find(&:required?)
       return redirect_to new_responsible_person_notification_component_nanomaterial_build_path(@notification.responsible_person, @notification, component, nano_element)
     elsif @notification.formulation_required?
-      component = @notification.components.find(&:formulation_required?)
+      component = @notification.components.order(:id).find(&:formulation_required?)
       return redirect_to new_responsible_person_notification_component_formulation_path(@notification.responsible_person, @notification, component)
     else
       @notification.formulation_file_uploaded!

--- a/cosmetics-web/app/controllers/nanomaterial_build_controller.rb
+++ b/cosmetics-web/app/controllers/nanomaterial_build_controller.rb
@@ -161,7 +161,7 @@ private
   end
 
   def get_next_nano_element
-    @nano_element.nano_material.nano_elements.each_cons(2) do |element, next_element|
+    @nano_element.nano_material.nano_elements.order(:id).each_cons(2) do |element, next_element|
       return next_element if element == @nano_element
     end
   end


### PR DESCRIPTION
When uploading a zip file, the application needs to loop you through any components and/or nanomaterials which need additional information.

This change makes sure that these are looped through in the database’s `id` order.  When this isn't specified, the order can be unpredictable (based upon Postgres internals), which was causing issues when writing tests.