### PR TITLE
Show Review Apps deployment information in PR

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -21,7 +21,7 @@ jobs:
           -d '{
           "ref": "'"$BRANCH"'",
           "description": "Review App deploy",
-          "environment": "reviewapp",
+          "environment": "int",
           "auto_merge": false,
           "required_contexts": []
           }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
@@ -51,6 +51,7 @@ jobs:
           -H "Accept: application/vnd.github.flash-preview+json" \
           $DEPLOY_STATUSES_URL \
           -d '{
+            "environment": "int",
             "state": "in_progress",
             "description": "Deployment initiated",
             "log_url": "'"$PR_CHECKS_URL"'"
@@ -85,15 +86,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        PR_CHECKS_URL: ${{ env.PR_CHECKS_URL }}
+        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
+        DEPLOYED_WEBSITE="https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/"
+
         curl -X POST \
           -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.ant-man-preview+json" \
           $DEPLOY_STATUSES_URL \
           -d '{
+            "environment": "int",
             "state": "success",
             "description": "Deployment succeeded",
-            "log_url": "https://github.com/UKGovernmentBEIS/beis-opss/pull/1637/checks?check_run_id=403423055"
+            "environment_url": "'"$DEPLOYED_WEBSITE"'",
+            "log_url": "'"$PR_CHECKS_URL"'"
           }'
 
     - name: Update deployment status (failure)
@@ -108,6 +115,7 @@ jobs:
           -H "Accept: application/vnd.github.ant-man-preview+json" \
           $DEPLOY_STATUSES_URL \
           -d '{
+            "environment": "int",
             "state": "failure",
             "description": "Deployment failed",
             "log_url": "'"$PR_CHECKS_URL"'"

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -9,12 +9,60 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+
+    - name: Create GitHub deployment
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: ${{ github.head_ref }}
+      run: |
+        DEPLOY_URL=$(curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          -d '{
+          "ref": "'"$BRANCH"'",
+          "description": "Review App deploy",
+          "environment": "reviewapp",
+          "auto_merge": false,
+          "required_contexts": []
+          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
+
+        if [ -z "$DEPLOY_URL" ]; then
+          echo "Failed to create Github deployment"
+        else
+          # We need these values to be shared between steps
+          echo "::set-env name=PR_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')"
+          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
+          echo "Github deployment created: $DEPLOY_URL"
+        fi
+
+    - name: Initiate deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
+        # The Pull Request checks URL needs to be available in further steps
+        PR_CHECKS_URL=$(echo "https://github.com/UKGovernmentBEIS/beis-opss/pull/$PR_NUMBER/checks")
+        echo "::set-env name=PR_CHECKS_URL::$PR_CHECKS_URL"
+
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          -H "Accept: application/vnd.github.flash-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "state": "in_progress",
+            "description": "Deployment initiated",
+            "log_url": "'"$PR_CHECKS_URL"'"
+          }'
+
     - name: Install cf client
       env:
         CF_CLI_VERSION: 7.0.0-beta.25
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
+
     - name: Deploy
       env:
         SPACE: int
@@ -31,3 +79,36 @@ jobs:
         export REDIS_NAME=cosmetics-review-redis-$PR_NUMBER
         ./cosmetics-web/deploy-review.sh
         cf7 logout
+
+    - name: Update deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "state": "success",
+            "description": "Deployment succeeded",
+            "log_url": "https://github.com/UKGovernmentBEIS/beis-opss/pull/1637/checks?check_run_id=403423055"
+          }'
+
+    - name: Update deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        PR_CHECKS_URL: ${{ env.PR_CHECKS_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "state": "failure",
+            "description": "Deployment failed",
+            "log_url": "'"$PR_CHECKS_URL"'"
+          }'


### PR DESCRIPTION
## Description
This PR introduce the usage of Github Deploy API to display review apps deploy information.

When the review app deployment gets initiated will show the progress:

![Screenshot from 2020-01-27 11-20-00](https://user-images.githubusercontent.com/1227578/73171368-7d829b80-40f8-11ea-94dc-7fc304cd5c6f.png)

Through the **"Deployed"** link we will be able to jump to the Pull request checks and track the progress of the deployment:
![Screenshot from 2020-01-27 11-21-35](https://user-images.githubusercontent.com/1227578/73171426-9b500080-40f8-11ea-99d7-76ad4ac8ca86.png)


Once deployed, a "**View Deployment**" link will be displayed so the review app can be directly accessed:
![Screenshot from 2020-01-27 12-08-19](https://user-images.githubusercontent.com/1227578/73173704-ea4c6480-40fd-11ea-9115-4f39e669756e.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
