### PR TITLE
Show deploy information for Staging and Production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success staging
+        gh_deploy_success staging https://staging-submit.cosmetic-product-notifications.service.gov.uk/
 
     - name: Update Staging deployment status (failure)
       if: failure()
@@ -109,7 +109,7 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success production
+        gh_deploy_success production https://submit.cosmetic-product-notifications.service.gov.uk/
 
     - name: Update Production deployment status (failure)
       if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,44 +21,18 @@ jobs:
     - name: Create GitHub deployment for Staging
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: master
       run: |
-        DEPLOY_URL=$(curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
-          -d '{
-          "ref": "master",
-          "description": "Staging deploy",
-          "environment": "staging",
-          "auto_merge": false,
-          "required_contexts": []
-          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
-
-        if [ -z "$DEPLOY_URL" ]; then
-          echo "Failed to create Github deployment"
-        else
-          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
-          echo "Github deployment created: $DEPLOY_URL"
-        fi
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_create staging
 
     - name: Initiate Staging deployment status
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
       run: |
-        ACTIONS_DEPLOY_URL=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Amaster+workflow%3ADeploy")
-        echo "::set-env name=ACTIONS_DEPLOY_URL::$ACTIONS_DEPLOY_URL" # Export for future steps
-
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          -H "Accept: application/vnd.github.flash-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "staging",
-            "state": "in_progress",
-            "description": "Staging deployment initiated",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_initiate staging
 
     - name: Deploy to Staging
       env:
@@ -80,78 +54,37 @@ jobs:
       if: success()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "staging",
-            "state": "success",
-            "description": "Staging deployment succeeded",
-            "environment_url": "https://staging-submit.cosmetic-product-notifications.service.gov.uk/",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_success staging
 
     - name: Update Staging deployment status (failure)
       if: failure()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "staging",
-            "state": "failure",
-            "description": "Staging deployment failed",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_failure staging
 
     - name: Create GitHub deployment for Production
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        BRANCH: master
       run: |
-        DEPLOY_URL=$(curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
-          -d '{
-          "ref": "master",
-          "description": "Production deploy",
-          "environment": "production",
-          "auto_merge": false,
-          "required_contexts": []
-          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
-
-        if [ -z "$DEPLOY_URL" ]; then
-          echo "Failed to create Github deployment"
-        else
-          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
-          echo "Github deployment created: $DEPLOY_URL"
-        fi
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_create production
 
     - name: Initiate Production deployment status
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          -H "Accept: application/vnd.github.flash-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "production",
-            "state": "in_progress",
-            "description": "Production deployment initiated",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_initiate production
 
     - name: Deploy to production
       env:
@@ -172,35 +105,18 @@ jobs:
       if: success()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "production",
-            "state": "success",
-            "description": "Production deployment succeeded",
-            "environment_url": "https://submit.cosmetic-product-notifications.service.gov.uk/",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_success production
 
     - name: Update Production deployment status (failure)
       if: failure()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "production",
-            "state": "failure",
-            "description": "Production deployment failed",
-            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_failure production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,50 @@ jobs:
       run: |
         curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /tmp
         sudo cp /tmp/cf7 /usr/local/bin/cf7
-    - name: Deploy to staging
+
+    - name: Create GitHub deployment for Staging
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+      run: |
+        DEPLOY_URL=$(curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          -d '{
+          "ref": "master",
+          "description": "Staging deploy",
+          "environment": "staging",
+          "auto_merge": false,
+          "required_contexts": []
+          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
+
+        if [ -z "$DEPLOY_URL" ]; then
+          echo "Failed to create Github deployment"
+        else
+          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
+          echo "Github deployment created: $DEPLOY_URL"
+        fi
+
+    - name: Initiate Staging deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: https://github.com/UKGovernmentBEIS/beis-opss/actions?query=branch%3Amaster+workflow%3ADeploy
+      run: |
+        echo "::set-env name=ACTIONS_DEPLOY_URL::$ACTIONS_DEPLOY_URL" # Export for future steps
+
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          -H "Accept: application/vnd.github.flash-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "staging",
+            "state": "in_progress",
+            "description": "Staging deployment initiated",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'
+
+    - name: Deploy to Staging
       env:
         SPACE: staging
         APP_NAME: cosmetics-web
@@ -32,6 +75,84 @@ jobs:
         chmod +x ./cosmetics-web/deploy.sh
         ./cosmetics-web/deploy.sh
         cf7 logout
+
+    - name: Update Staging deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "staging",
+            "state": "success",
+            "description": "Staging deployment succeeded",
+            "environment_url": "https://staging-submit.cosmetic-product-notifications.service.gov.uk/",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'
+
+    - name: Update Staging deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "staging",
+            "state": "failure",
+            "description": "Staging deployment failed",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'
+
+    - name: Create GitHub deployment for Production
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+      run: |
+        DEPLOY_URL=$(curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          -d '{
+          "ref": "master",
+          "description": "Production deploy",
+          "environment": "production",
+          "auto_merge": false,
+          "required_contexts": []
+          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
+
+        if [ -z "$DEPLOY_URL" ]; then
+          echo "Failed to create Github deployment"
+        else
+          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
+          echo "Github deployment created: $DEPLOY_URL"
+        fi
+
+    - name: Initiate Production deployment status
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          -H "Accept: application/vnd.github.flash-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "production",
+            "state": "in_progress",
+            "description": "Production deployment initiated",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'
+
     - name: Deploy to production
       env:
         SPACE: prod
@@ -46,3 +167,40 @@ jobs:
         cf7 target -o 'beis-opss' -s $SPACE
         ./cosmetics-web/deploy.sh
         cf7 logout
+
+    - name: Update Production deployment status (success)
+      if: success()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "production",
+            "state": "success",
+            "description": "Production deployment succeeded",
+            "environment_url": "https://submit.cosmetic-product-notifications.service.gov.uk/",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'
+
+    - name: Update Production deployment status (failure)
+      if: failure()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        ACTIONS_DEPLOY_URL: ${{ env.ACTIONS_DEPLOY_URL }}
+      run: |
+        curl -X POST \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.ant-man-preview+json" \
+          $DEPLOY_STATUSES_URL \
+          -d '{
+            "environment": "production",
+            "state": "failure",
+            "description": "Production deployment failed",
+            "log_url": "'"$ACTIONS_DEPLOY_URL"'"
+          }'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         DEPLOY_URL=$(curl -X POST \
           -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
           -d '{
           "ref": "master",
           "description": "Staging deploy",
@@ -44,8 +44,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        ACTIONS_DEPLOY_URL: https://github.com/UKGovernmentBEIS/beis-opss/actions?query=branch%3Amaster+workflow%3ADeploy
       run: |
+        ACTIONS_DEPLOY_URL=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Amaster+workflow%3ADeploy")
         echo "::set-env name=ACTIONS_DEPLOY_URL::$ACTIONS_DEPLOY_URL" # Export for future steps
 
         curl -X POST \
@@ -119,7 +119,7 @@ jobs:
       run: |
         DEPLOY_URL=$(curl -X POST \
           -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
           -d '{
           "ref": "master",
           "description": "Production deploy",

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -60,7 +60,7 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success int
+        gh_deploy_success int https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/
 
     - name: Update deployment status (failure)
       if: failure()

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -15,47 +15,17 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         BRANCH: ${{ github.head_ref }}
       run: |
-        DEPLOY_URL=$(curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
-          -d '{
-          "ref": "'"$BRANCH"'",
-          "description": "Review App deploy",
-          "environment": "int",
-          "auto_merge": false,
-          "required_contexts": []
-          }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
-
-        if [ -z "$DEPLOY_URL" ]; then
-          echo "Failed to create Github deployment"
-        else
-          # We need these values to be shared between steps
-          echo "::set-env name=PR_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')"
-          echo "::set-env name=DEPLOY_URL::$DEPLOY_URL"
-          echo "Github deployment created: $DEPLOY_URL"
-        fi
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_create int
 
     - name: Initiate deployment status
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
-        # The Pull Request checks URL needs to be available in further steps
-        PR_CHECKS_URL=$(echo "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER/checks")
-        echo "::set-env name=PR_CHECKS_URL::$PR_CHECKS_URL"
-
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          -H "Accept: application/vnd.github.flash-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "int",
-            "state": "in_progress",
-            "description": "Deployment initiated",
-            "log_url": "'"$PR_CHECKS_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_initiate int
 
     - name: Install cf client
       env:
@@ -85,38 +55,19 @@ jobs:
       if: success()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        PR_CHECKS_URL: ${{ env.PR_CHECKS_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
-        DEPLOYED_WEBSITE="https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/"
-
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "int",
-            "state": "success",
-            "description": "Deployment succeeded",
-            "environment_url": "'"$DEPLOYED_WEBSITE"'",
-            "log_url": "'"$PR_CHECKS_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_success int
 
     - name: Update deployment status (failure)
       if: failure()
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
-        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_URL }}/statuses
-        PR_CHECKS_URL: ${{ env.PR_CHECKS_URL }}
+        DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
-        curl -X POST \
-          -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github.ant-man-preview+json" \
-          $DEPLOY_STATUSES_URL \
-          -d '{
-            "environment": "int",
-            "state": "failure",
-            "description": "Deployment failed",
-            "log_url": "'"$PR_CHECKS_URL"'"
-          }'
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_failure int

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         DEPLOY_URL=$(curl -X POST \
           -H "Authorization: token $GITHUB_TOKEN" \
-          https://api.github.com/repos/UKGovernmentBEIS/beis-opss/deployments \
+          https://api.github.com/repos/$GITHUB_REPOSITORY/deployments \
           -d '{
           "ref": "'"$BRANCH"'",
           "description": "Review App deploy",
@@ -42,7 +42,7 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         # The Pull Request checks URL needs to be available in further steps
-        PR_CHECKS_URL=$(echo "https://github.com/UKGovernmentBEIS/beis-opss/pull/$PR_NUMBER/checks")
+        PR_CHECKS_URL=$(echo "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER/checks")
         echo "::set-env name=PR_CHECKS_URL::$PR_CHECKS_URL"
 
         curl -X POST \

--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -53,7 +53,7 @@ gh_deploy_create() {
 # - GITHUB_TOKEN        - Github user token with deploy rights.
 # - GITHUB_REPOSITORY   - Set by default by Github. Formatted as "org/repo".
 # - PR_NUMBER           - Pull Request number. Only needed for "int" environment.
-# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set up by "gh_deploy_create"
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set up by "gh_deploy_create".
 #
 # Required system tools:
 # - curl
@@ -82,26 +82,20 @@ gh_deploy_initiate() {
 # Sets Github deploy status as "success"
 #
 # Input:
-# - Deployment environment to update the status at.
-#   eg: $ gh_deploy_success staging
+# - 1. Deployment environment to update the status at.
+# - 2. Environment url where the deployed changes can be viewed.
+#   eg: $ gh_deploy_success staging https://opss-service.digital/
 #
 # Required environment variables:
 # - GITHUB_TOKEN        - Github user token with deploy rights.
-# - PR_NUMBER           - Pull Request number. Only needed for "int" environment.
-# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set up by "gh_deploy_create"
-# - LOG_URL             - URL to track the deployment progress. Set up by "gh_deploy_initiate"
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set by "gh_deploy_create".
+# - LOG_URL             - URL to track the deployment progress. Set by "gh_deploy_initiate".
 #
 # Required system tools:
 # - curl
 gh_deploy_success() {
   environment_name=$1
-  if [ "$environment_name" == "int" ]; then
-    environment_url="https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/"
-  elif [ "$environment_name" == "staging" ]; then
-    environment_url="https://staging-submit.cosmetic-product-notifications.service.gov.uk/"
-  elif [ "$environment_name" == "production" ]; then
-    environment_url="https://submit.cosmetic-product-notifications.service.gov.uk/"
-  fi
+  environment_url=$2
 
   curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
@@ -124,8 +118,8 @@ gh_deploy_success() {
 #
 # Required environment variables:
 # - GITHUB_TOKEN        - Github user token with deploy rights.
-# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set up by "gh_deploy_create"
-# - LOG_URL             - URL to track the deployment progress. Set up by "gh_deploy_initiate"
+# - DEPLOY_STATUSES_URL - URL for Github deployment statuses. Set by "gh_deploy_create".
+# - LOG_URL             - URL to track the deployment progress. Set by "gh_deploy_initiate".
 #
 # Required system tools:
 # - curl


### PR DESCRIPTION
Github deployments API will track the deployment of both Staging and
Production environments when new commits are pushed into master branch.

When the deployments succeed, Github deploy information will show a
link for each of the deployed environments.

## Description
The process is the same in each environment deployed:

1. Create a Github deployment for the environment.
2. Set deployment status as initiated.
3. Deploy the environment.
4. Set deploy status as success or failure depending on the deploy result.
5. When successful, a link to the deployment environment will be displayed.

Related to https://github.com/UKGovernmentBEIS/beis-opss/pull/1637

## Alert for Reviewers

I don't recall a way to test this workflow without actually merging it into master and :crossed_fingers:. So if it doesn't work on the first attempt this can turn into a "fix/push/merge/deploy" nasty nightmare with the staging/production deploy...

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
