### PR TITLE
Pin Ruby buildpack to v1.8.4 to maintain compatibility

### DIFF
--- a/cosmetics-web/manifest.review.yml
+++ b/cosmetics-web/manifest.review.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((cosmetics-instance-name))
   buildpacks:
-    - ruby_buildpack
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   path: .
   routes:
     - route: ((search-host))

--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((app-name))
   buildpacks:
-    - ruby_buildpack
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   routes:
     - route: ((search-host))
     - route: ((submit-host))

--- a/cosmetics-worker/manifest.yml
+++ b/cosmetics-worker/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: cosmetics-worker
   memory: 1G
   buildpacks:
-    - ruby_buildpack
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   instances: 1
   path: ../cosmetics-web
   command: export $(./env/get-env-from-vcap.sh) && bin/yarn install && bin/sidekiq -C config/sidekiq.yml

--- a/infrastructure/fluentd/manifest.yml
+++ b/infrastructure/fluentd/manifest.yml
@@ -4,7 +4,7 @@ applications:
   memory: 256M
   instances: 1
   buildpacks:
-    - ruby_buildpack
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.4
   path: .
   command: bin/fluentd -c ./fluent.conf -p ./plugins/
   stack: cflinuxfs3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
The new Ruby buildpack is [currently broken](https://github.com/UKGovernmentBEIS/beis-opss/pull/1644) so this change pins to the last known working version. It's a short term fix while we investigate fixing the issue, but it also means we can be sure it can continue to deploy should the project be halted.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
