### PR TITLE
Set individual Github environments for reviewapp deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,12 @@ jobs:
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_initiate staging
+
+        # URL where the deployment progress can be tracked. Exported for future steps.
+        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/actions?query=branch%3Amaster+workflow%3ADeploy")
+        echo "::set-env name=LOG_URL::$log_url"
+
+        gh_deploy_initiate staging $log_url
 
     - name: Deploy to Staging
       env:

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -22,7 +22,7 @@ jobs:
         PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
-        gh_deploy_create review-app-${PR_NUMBER}
+        gh_deploy_create --transient review-app-${PR_NUMBER}
 
     - name: Initiate deployment status
       env:

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -16,7 +16,13 @@ jobs:
         BRANCH: ${{ github.head_ref }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_create int
+
+        # Review apps need the Pull Request number for their environment
+        # name and to be able to be linked to the specific PR checks.
+        PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
+
+        gh_deploy_create review-app-${PR_NUMBER}
 
     - name: Initiate deployment status
       env:
@@ -25,7 +31,7 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_initiate int
+        gh_deploy_initiate review-app-${PR_NUMBER}
 
     - name: Install cf client
       env:
@@ -60,7 +66,7 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success int https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/
+        gh_deploy_success review-app-${PR_NUMBER} https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/
 
     - name: Update deployment status (failure)
       if: failure()
@@ -68,6 +74,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
         LOG_URL: ${{ env.LOG_URL }}
+        PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_failure int
+        gh_deploy_failure review-app-${PR_NUMBER}

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -31,7 +31,12 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_initiate review-app-${PR_NUMBER}
+
+        # URL where the deployment progress can be tracked. Exported for future steps.
+        log_url=$(echo "https://github.com/$GITHUB_REPOSITORY/pull/$PR_NUMBER/checks")
+        echo "::set-env name=LOG_URL::$log_url"
+
+        gh_deploy_initiate review-app-${PR_NUMBER} $log_url
 
     - name: Install cf client
       env:
@@ -66,7 +71,10 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success review-app-${PR_NUMBER} https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/
+
+        environment_url=https://cosmetics-pr-${PR_NUMBER}-submit-web.london.cloudapps.digital/
+
+        gh_deploy_success review-app-${PR_NUMBER} $LOG_URL $environment_url
 
     - name: Update deployment status (failure)
       if: failure()
@@ -77,4 +85,4 @@ jobs:
         PR_NUMBER: ${{ env.PR_NUMBER }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_failure review-app-${PR_NUMBER}
+        gh_deploy_failure review-app-${PR_NUMBER} $LOG_URL

--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -4,8 +4,11 @@ set -e
 # Creates a Deploy in Github
 #
 # Input:
-# - Name of the environment to deploy at.
-#   eg: $ gh_deploy_create staging
+# 1. Transient flag (optional): -t | --transient.
+# 2. Name of the environment to deploy at.
+#   eg:  $ gh_deploy_create staging
+#   eg:  $ gh_deploy_create -t review-app-15
+#   eg:  $ gh_deploy_create --transient review-app-15
 #
 # Required environment variables:
 # - GITHUB_TOKEN      - Github user token with deploy rights.
@@ -14,17 +17,21 @@ set -e
 # - GITHUB_REF        - Set by default by Github.
 #
 # Required system tools:
+# - getopt
 # - curl
 # - jq
 # - awk
 gh_deploy_create() {
-  environment_name=$1
-
-  if [[ $environment_name == review* ]]; then
+  # Set the environment as transient depending on a optionally
+  # given flag when calling the function.
+  if [[ $1 == "-t" || $1 == "--transient" ]]; then
     transient_environment=true
+    shift # The second argument becomes $1
   else
     transient_environment=false
   fi
+  environment_name=$1
+  echo "Transient Environment: $transient_environment"
 
   deploy_url=$(curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
## Description
All the reviewapps are being deployed under "int" environment on Github deployments, matching the BEIS PaaS "int" Space that hosts all the review apps.

This approach has a critical downside though: 
**New PRs deploys are considered as the latest version of the same "int" environment**, and Github Deployment tags
the previously deployed PRs as "innactive", removing he deployment information and environment URL.
As a consequence of this, we cannot have multiple PRs opened in parallel showing Deployment & Environment information.

## Solution
In order to avoid this, we are creating individual environments for each Pull Request number. So multiple review app environments will be cohabiting in Github Deployment domain without stepping over each other.
This approach was suggested by @frankieroberto [over previous PR](https://github.com/UKGovernmentBEIS/beis-opss/pull/1646#discussion_r373568175) (thanks! :clap: )

## Example of the issue when sharing "int"
Two different PRs, the first one has been deployed under "int". The second PR deployment has started:
![Screenshot from 2020-02-03 15-22-20](https://user-images.githubusercontent.com/1227578/73672371-a381e000-46a4-11ea-8bb1-9fa065189911.png)

Once the second PR finishes, the firs PR "View deployment" button disappears, as that deploy gets considered outdated and marked as "inactive":
![Screenshot from 2020-02-03 15-26-12](https://user-images.githubusercontent.com/1227578/73672446-cad8ad00-46a4-11ea-9e79-adceedc3543e.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
