### PR TITLE
Fix missing urls in staging and production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,8 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success staging https://staging-submit.cosmetic-product-notifications.service.gov.uk/
+        environment_url=https://staging-submit.cosmetic-product-notifications.service.gov.uk/
+        gh_deploy_success staging $LOG_URL $environment_url
 
     - name: Update Staging deployment status (failure)
       if: failure()
@@ -73,7 +74,7 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_failure staging
+        gh_deploy_failure staging $LOG_URL
 
     - name: Create GitHub deployment for Production
       env:
@@ -87,9 +88,10 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
         DEPLOY_STATUSES_URL: ${{ env.DEPLOY_STATUSES_URL }}
+        LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_initiate production
+        gh_deploy_initiate production $LOG_URL
 
     - name: Deploy to production
       env:
@@ -114,7 +116,8 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_success production https://submit.cosmetic-product-notifications.service.gov.uk/
+        environment_url=https://submit.cosmetic-product-notifications.service.gov.uk/
+        gh_deploy_success production $LOG_URL $environment_url
 
     - name: Update Production deployment status (failure)
       if: failure()
@@ -124,4 +127,4 @@ jobs:
         LOG_URL: ${{ env.LOG_URL }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_failure production
+        gh_deploy_failure production $LOG_URL


### PR DESCRIPTION
## Description
When [URLs where extracted from the Bash deploy functions](https://github.com/UKGovernmentBEIS/beis-opss/pull/1657/commits/f9388518836168b083e22e5c52f75267ddc965f2) to the workflows, I forgot to pass them as parameter to the functions when calling them from Staging/Production deploy workflow.

As a result, the environment URL is showing up as the log URL instead of showing a button near the Deployment info, while the log URL to track the deploy process is not being displayed at all.

This change adds the missing argument.
![image](https://user-images.githubusercontent.com/1227578/73767886-02f8f200-4770-11ea-9341-acc804e3f1ef.png)
