### PR TITLE
Stop setting review apps as transient deploys

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -22,7 +22,7 @@ jobs:
         PR_NUMBER=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
-        gh_deploy_create --transient review-app-${PR_NUMBER}
+        gh_deploy_create review-app-${PR_NUMBER}
 
     - name: Initiate deployment status
       env:

--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -4,11 +4,8 @@ set -e
 # Creates a Deploy in Github
 #
 # Input:
-# - 1. Transient flag (optional): -t | --transient.
-# - 2. Name of the environment to deploy at.
+# - 1. Name of the environment to deploy at.
 # - eg:  $ gh_deploy_create staging
-# - eg:  $ gh_deploy_create -t review-app-15
-# - eg:  $ gh_deploy_create --transient review-app-15
 #
 # Required environment variables:
 # - GITHUB_TOKEN      - Github user token with deploy rights.
@@ -22,16 +19,7 @@ set -e
 # - jq
 # - awk
 gh_deploy_create() {
-  # Set the environment as transient depending on a optionally
-  # given flag when calling the function.
-  if [[ $1 == "-t" || $1 == "--transient" ]]; then
-    transient_environment=true
-    shift # The second argument becomes $1
-  else
-    transient_environment=false
-  fi
   environment_name=$1
-  echo "Transient Environment: $transient_environment"
 
   deploy_url=$(curl -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \
@@ -41,7 +29,6 @@ gh_deploy_create() {
     "ref": "'"$BRANCH"'",
     "description": "'"$environment_name"' deploy created",
     "environment": "'"$environment_name"'",
-    "transient_environment": '"$transient_environment"',
     "auto_merge": false,
     "required_contexts": []
     }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.


### PR DESCRIPTION
We guessed marking them as transient would reproduce Heroku review apps
behaviour, but instead what happened is:
- Review apps environments with transient deploys don't get their own
  info box as the rest of environments in the Github deployments list.
- Each time a new commit is pushed into the affected Pull Request,
  triggering a new deploy, the previous deploy is still listed as
  active instead of being replaced by the new one. So you get a deploy
  link per push.
  This is completely unnecessary as all these deploys contain a list to
  the same "review-app-xxx" environment. So we just need the latest
  deploy to be "active" and the previous ones being automatically
  inactivated.

Given that, going back to the default non-transient approach is more
adequate for our needs.

