### PR TITLE
Set GitHub deploys as inactive when pr merged

### DIFF
--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -24,21 +24,27 @@ jobs:
     - name: Get Pull Request ID using GitHub API
       if: github.event.pull_request.merged == true
       run: |
-        export PR_NUMBER=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
-        cf7 api api.london.cloud.service.gov.uk
-        cf7 auth
-        cf7 target -o 'beis-opss' -s $SPACE
-        cf7 delete -f -r cosmetics-pr-$PR_NUMBER
-        cf7 delete-service -f cosmetics-review-redis-$PR_NUMBER
-        cf7 logout
+        pr_number=`curl -H "Accept: application/vnd.github.groot-preview+json" https://api.github.com/repos/UKGovernmentBEIS/beis-opss/commits/$GITHUB_SHA/pulls | ./infrastructure/env/jq '.[0] | .number'`
+        echo "::set-env name=PR_NUMBER::$pr_number"
     - name: Get Pull Request ID from GITHUB_REF
       if: github.event.pull_request.merged != true
       run: |
-        export PR_NUMBER=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
+        pr_number=`echo $GITHUB_REF | grep -o '[0-9_]\+'`
+        echo "::set-env name=PR_NUMBER::$pr_number"
+    - name: Delete review app
+      env:
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+      run: |
         cf7 api api.london.cloud.service.gov.uk
         cf7 auth
         cf7 target -o 'beis-opss' -s $SPACE
         cf7 delete -f -r cosmetics-pr-$PR_NUMBER
         cf7 delete-service -f cosmetics-review-redis-$PR_NUMBER
         cf7 logout
-
+    - name: Inactivate Github deploy
+      env:
+        PR_NUMBER: ${{ env.PR_NUMBER }}
+        GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
+      run: |
+        source cosmetics-web/deploy-github-functions.sh
+        gh_deploy_inactivate_dandling review-app-$PR_NUMBER

--- a/.github/workflows/review-apps-delete.yml
+++ b/.github/workflows/review-apps-delete.yml
@@ -41,10 +41,10 @@ jobs:
         cf7 delete -f -r cosmetics-pr-$PR_NUMBER
         cf7 delete-service -f cosmetics-review-redis-$PR_NUMBER
         cf7 logout
-    - name: Inactivate Github deploy
+    - name: Deactivate Github deploy
       env:
         PR_NUMBER: ${{ env.PR_NUMBER }}
         GITHUB_TOKEN: ${{ secrets.GithubApiDeploymentToken }}
       run: |
         source cosmetics-web/deploy-github-functions.sh
-        gh_deploy_inactivate_dandling review-app-$PR_NUMBER
+        gh_deploy_deactivate_dangling review-app-$PR_NUMBER

--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -210,9 +210,11 @@ gh_deploy_deactivate_dangling() {
     IFS='@' read deploy_id deploy_environment deploy_ref <<< $deploy
     # We only want to deactivate Review Apps.
     if [[ $deploy_environment != "staging" && $deploy_environment != "production" ]]; then
+      # Extracts Organization name from "org/repo".
+      IFS='/' read -r org repo <<< $GITHUB_REPOSITORY
       # Number of open Pull Requests belonging to the branch.
       # We assume "deploy_ref" is a branch as our GH deploys use branch as ref.
-      open_prs=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=open&head=UKGovernmentBEIS:$deploy_ref" | jq '. | length')
+      open_prs=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls?state=open&head=${org}:${deploy_ref}" | jq '. | length')
       # If there are no open PRs from the branch we can safely deactivate this branch deploys.
       if [[ $open_prs -eq 0 ]]; then
         # Gets most recent status for the deploy.

--- a/cosmetics-web/deploy-github-functions.sh
+++ b/cosmetics-web/deploy-github-functions.sh
@@ -31,7 +31,7 @@ gh_deploy_create() {
     "environment": "'"$environment_name"'",
     "auto_merge": false,
     "required_contexts": []
-    }' | jq '.url?' | tr -d '"') # Gets 'url' field from the response and trims the surronding quotes.
+    }' | jq -r '.url?') # Gets 'url' field from the response
 
   if [ -z "$deploy_url" ]; then
     echo "Failed to create Github deployment"


### PR DESCRIPTION
[JIRA-821](https://regulatorydelivery.atlassian.net/browse/COSBETA-821)

## Description
On top of deleting the review app itself when a Pull Request is merged or closed, we want to set the status of the corresponding GitHub deployment as "inactive", so we won't have a "View Deployment" link for an environment that does not exist anymore.

